### PR TITLE
refactor: centralize navigation links

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -2,17 +2,7 @@ import Link from "next/link";
 import { Facebook, Instagram } from "lucide-react";
 import { WhatsAppIcon } from "@/components/icons/whatsapp-icon";
 import { Logo } from "../icons/logo";
-
-const navLinks = [
-  { href: "/producers", label: "For Producers" },
-  { href: "/become-a-partner", label: "Partner With Us" },
-  { href: "/#services", label: "Services" },
-  { href: "/#locations", label: "Branches" },
-  { href: "/#gallery", label: "Gallery" },
-  { href: "/#wholesale", label: "Wholesale" },
-  { href: "/#contact", label: "Contact Us" },
-  { href: "/store", label: "Online Store" },
-];
+import { navLinks } from "@/lib/nav-links";
 
 export function Footer() {
   return (

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -6,18 +6,8 @@ import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { navLinks } from "@/lib/nav-links";
 import { Logo } from "../icons/logo";
-
-const navLinks = [
-  { href: "/producers", label: "For Producers" },
-  { href: "/become-a-partner", label: "Partner With Us" },
-  { href: "/#services", label: "Services" },
-  { href: "/#locations", label: "Branches" },
-  { href: "/#gallery", label: "Gallery" },
-  { href: "/#wholesale", label: "Wholesale" },
-  { href: "/#contact", label: "Contact Us" },
-  { href: "/store", label: "Online Store" },
-];
 
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);

--- a/src/lib/nav-links.ts
+++ b/src/lib/nav-links.ts
@@ -1,0 +1,15 @@
+export type NavLink = {
+  href: string;
+  label: string;
+};
+
+export const navLinks: NavLink[] = [
+  { href: "/producers", label: "For Producers" },
+  { href: "/become-a-partner", label: "Partner With Us" },
+  { href: "/#services", label: "Services" },
+  { href: "/#locations", label: "Branches" },
+  { href: "/#gallery", label: "Gallery" },
+  { href: "/#wholesale", label: "Wholesale" },
+  { href: "/#contact", label: "Contact Us" },
+  { href: "/store", label: "Online Store" },
+];


### PR DESCRIPTION
## Summary
- add shared `navLinks` module
- reuse `navLinks` in header and footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: project prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Type 'string | boolean' is not assignable to type 'boolean')*


------
https://chatgpt.com/codex/tasks/task_e_68c7a939028c83209f663c17bcaa0e83