### PR TITLE
Fix logo display paths and ensure typecheck passes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title: "Valley Farm Secrets",
   description: "Freshness. Quality. Convenience. Your farm-to-table partner.",
   icons: {
-    icon: "/logo.png",
+    icon: "/images/logo.png",
   },
 };
 
@@ -25,7 +25,7 @@ export default function RootLayout({
     href="https://fonts.googleapis.com/css2?family=Alegreya:wght@700&family=Poppins:wght@400;600&display=swap"
     rel="stylesheet"
   />
-  <link rel="icon" href="/logo.png" type="image/png" />
+  <link rel="icon" href="/images/logo.png" type="image/png" />
 </head>
       <body className={cn("font-body antialiased", "min-h-screen bg-background font-sans")}>
         {children}

--- a/src/components/icons/logo.tsx
+++ b/src/components/icons/logo.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 export function Logo(props: { className?: string }) {
   return (
     <Image
-      src="/logo.png"
+      src="/images/logo.png"
       alt="Valley Farm Secrets Logo"
       width={40}
       height={40}

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -49,7 +49,7 @@ export function StoreLayout() {
     });
   }, [searchTerm, showSpecialsOnly, selectedCategory, sortOption]);
 
-  const hasActiveFilter = searchTerm || showSpecialsOnly || selectedCategory !== "All";
+  const hasActiveFilter = Boolean(searchTerm) || showSpecialsOnly || selectedCategory !== "All";
 
   return (
     <div className="container mx-auto px-4 md:px-6 py-8">


### PR DESCRIPTION
## Summary
- fix missing logo by pointing Logo component and metadata to `/images/logo.png`
- correct store layout boolean filter to satisfy TypeScript

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68c7ab8ca5a88320a8d21f2e38bc8026