### PR TITLE
feat: log form submissions via API

### DIFF
--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const data = await req.json();
+    console.log("Form submission received:", data);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error handling form submission:", error);
+    return NextResponse.json({ success: false }, { status: 500 });
+  }
+}

--- a/src/app/become-a-partner/page.tsx
+++ b/src/app/become-a-partner/page.tsx
@@ -83,13 +83,34 @@ export default function BecomeAPartnerPage() {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log("Partnership Proposal:", values);
-    toast({
-      title: "✅ Thank you for submitting your partnership proposal to Valley Farm Secrets.",
-      description: "Our team will review it and get back to you within 5–7 working days. For urgent queries: +263 788 679 000 | +263 711 406 919.",
-    });
-    form.reset();
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      const response = await fetch("/api/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ form: "partner", ...values }),
+      });
+
+      if (response.ok) {
+        toast({
+          title: "✅ Thank you for submitting your partnership proposal to Valley Farm Secrets.",
+          description: "Our team will review it and get back to you within 5–7 working days. For urgent queries: +263 788 679 000 | +263 711 406 919.",
+        });
+        form.reset();
+      } else {
+        toast({
+          title: "Submission failed",
+          description: "Please try again later.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      toast({
+        title: "Submission failed",
+        description: "Please try again later.",
+        variant: "destructive",
+      });
+    }
   }
 
 

--- a/src/components/pages/home/wholesale.tsx
+++ b/src/components/pages/home/wholesale.tsx
@@ -32,13 +32,34 @@ export function Wholesale() {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log(values); // In a real app, you'd send this to a server
-    toast({
-      title: "Quote Request Sent!",
-      description: "Thank you! We will get back to you shortly.",
-    });
-    form.reset();
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      const response = await fetch("/api/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ form: "wholesale", ...values }),
+      });
+
+      if (response.ok) {
+        toast({
+          title: "Quote Request Sent!",
+          description: "Thank you! We will get back to you shortly.",
+        });
+        form.reset();
+      } else {
+        toast({
+          title: "Submission failed",
+          description: "Please try again later.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      toast({
+        title: "Submission failed",
+        description: "Please try again later.",
+        variant: "destructive",
+      });
+    }
   }
 
   return (

--- a/src/components/pages/producers/pre-booking-form.tsx
+++ b/src/components/pages/producers/pre-booking-form.tsx
@@ -54,13 +54,34 @@ export function PreBookingForm() {
 
   const transportRequired = form.watch("transportRequired");
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log(values); // In a real app, you'd send this to an API
-    toast({
-      title: "Booking Submitted!",
-      description: "Thank you for pre-booking your harvest with us. We'll be in touch.",
-    });
-    form.reset();
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      const response = await fetch("/api/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ form: "prebooking", ...values }),
+      });
+
+      if (response.ok) {
+        toast({
+          title: "Booking Submitted!",
+          description: "Thank you for pre-booking your harvest with us. We'll be in touch.",
+        });
+        form.reset();
+      } else {
+        toast({
+          title: "Submission failed",
+          description: "Please try again later.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      toast({
+        title: "Submission failed",
+        description: "Please try again later.",
+        variant: "destructive",
+      });
+    }
   }
 
   return (

--- a/src/components/pages/store/checkout-dialog.tsx
+++ b/src/components/pages/store/checkout-dialog.tsx
@@ -71,15 +71,36 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
   const subtotal = state.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
   const total = subtotal + (deliveryMethod === 'delivery' ? BIKER_DELIVERY_FEE : 0);
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log("Order placed:", { ...values, items: state.items, total });
-    toast({
-      title: "Order Placed Successfully!",
-      description: "Thank you for your purchase. You'll receive a confirmation shortly.",
-    });
-    dispatch({ type: 'CLEAR_CART' });
-    onOpenChange(false);
-    reset();
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      const response = await fetch("/api/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ form: "checkout", ...values, items: state.items, total }),
+      });
+
+      if (response.ok) {
+        toast({
+          title: "Order Placed Successfully!",
+          description: "Thank you for your purchase. You'll receive a confirmation shortly.",
+        });
+        dispatch({ type: 'CLEAR_CART' });
+        onOpenChange(false);
+        reset();
+      } else {
+        toast({
+          title: "Order failed",
+          description: "Please try again later.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      toast({
+        title: "Order failed",
+        description: "Please try again later.",
+        variant: "destructive",
+      });
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- remove client-side console logs and route form submissions through a new `/api/log` endpoint
- surface success or failure via toast notifications in partner, wholesale, pre-booking, and checkout forms

## Testing
- `npm run lint` *(fails: configuration prompt)*
- `npm run typecheck` *(fails: src/components/pages/store/store-layout.tsx(96,13): Type 'string | boolean' is not assignable to type 'boolean')*


------
https://chatgpt.com/codex/tasks/task_e_68c7aad2e7b883209ba5038f2fad302b