### PR TITLE
Use single hero image

### DIFF
--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -1,66 +1,27 @@
 "use client"
 
-import React, { useState, useEffect } from 'react';
 import Image from "next/image";
 import Link from "next/link";
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-} from "@/components/ui/carousel";
-import Autoplay from "embla-carousel-autoplay";
 import { Button } from "@/components/ui/button";
-import { PlaceHolderImages, ImagePlaceholder } from "@/lib/placeholder-images";
+import { PlaceHolderImages } from "@/lib/placeholder-images";
 
 export function Hero() {
-  const [heroImages, setHeroImages] = useState<ImagePlaceholder[]>([]);
-
-  useEffect(() => {
-    const allHeroImages = PlaceHolderImages.filter(p => p.id.startsWith("hero-"));
-    const shuffledImages = [...allHeroImages].sort(() => Math.random() - 0.5);
-    setHeroImages(shuffledImages);
-  }, []);
-
-  const plugin = React.useRef(
-    Autoplay({
-      delay: 4000,
-      stopOnInteraction: false,
-      stopOnMouseEnter: true,
-    })
-  );
+  const heroImage = PlaceHolderImages.find(p => p.id === "hero-produce");
 
   return (
     <section className="relative h-[80svh] w-full overflow-hidden">
-       <Carousel
-        plugins={[plugin.current]}
-        className="absolute inset-0 w-full h-full"
-        opts={{
-          loop: true,
-        }}
-      >
-        <CarouselContent className="h-full">
-          {heroImages.length > 0 ? (
-            heroImages.map((heroImage, index) => (
-             heroImage && (
-              <CarouselItem key={heroImage.id} className="h-full">
-                  <Image
-                      src={heroImage.imageUrl}
-                      alt={heroImage.description}
-                      fill
-                      className="object-cover animate-fade-in"
-                      priority={index === 0}
-                      data-ai-hint={heroImage.imageHint}
-                    />
-              </CarouselItem>
-            )
-          ))
-          ) : (
-             <CarouselItem className="h-full">
-                <div className="w-full h-full bg-secondary" />
-             </CarouselItem>
-          )}
-        </CarouselContent>
-      </Carousel>
+      {heroImage ? (
+        <Image
+          src={heroImage.imageUrl}
+          alt={heroImage.description}
+          fill
+          className="object-cover"
+          priority
+          data-ai-hint={heroImage.imageHint}
+        />
+      ) : (
+        <div className="w-full h-full bg-secondary" />
+      )}
 
       <div className="absolute inset-0 bg-black/50" />
       <div className="relative z-10 flex h-full flex-col items-center justify-center text-center text-white p-4">
@@ -71,10 +32,19 @@ export function Hero() {
           Your trusted partner for farm-fresh produce, from our fields to your table.
         </p>
         <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-          <Button asChild size="lg" className="bg-primary hover:bg-primary/90 text-primary-foreground transform transition-transform hover:scale-105">
+          <Button
+            asChild
+            size="lg"
+            className="bg-primary hover:bg-primary/90 text-primary-foreground transform transition-transform hover:scale-105"
+          >
             <Link href="/store">Shop Online</Link>
           </Button>
-          <Button asChild size="lg" variant="secondary" className="bg-accent hover:bg-accent/90 text-accent-foreground transform transition-transform hover:scale-105">
+          <Button
+            asChild
+            size="lg"
+            variant="secondary"
+            className="bg-accent hover:bg-accent/90 text-accent-foreground transform transition-transform hover:scale-105"
+          >
             <Link href="#wholesale">Wholesale Enquiries</Link>
           </Button>
         </div>

--- a/src/lib/placeholder-images.json
+++ b/src/lib/placeholder-images.json
@@ -1,52 +1,10 @@
 {
   "placeholderImages": [
     {
-      "id": "hero-1",
+      "id": "hero-produce",
       "description": "A vibrant assortment of fresh fruits and vegetables.",
-      "imageUrl": "/images/hero-1.webp",
+      "imageUrl": "/images/hero-produce.webp",
       "imageHint": "fresh produce"
-    },
-    {
-      "id": "hero-2",
-      "description": "A pristine butchery counter with various cuts of fresh meat.",
-      "imageUrl": "/images/hero-2.webp",
-      "imageHint": "butchery counter"
-    },
-    {
-      "id": "hero-3",
-      "description": "Shelves stocked with groceries and a variety of spices.",
-      "imageUrl": "/images/hero-3.webp",
-      "imageHint": "grocery spices"
-    },
-    {
-      "id": "hero-4",
-      "description": "A delivery truck being loaded with produce boxes for wholesale.",
-      "imageUrl": "/images/hero-4.webp",
-      "imageHint": "wholesale delivery"
-    },
-    {
-      "id": "hero-5",
-      "description": "Neatly arranged pre-packaged vegetables ready for sale.",
-      "imageUrl": "/images/hero-5.webp",
-      "imageHint": "prepackaged vegetables"
-    },
-    {
-      "id": "hero-6",
-      "description": "A person inspecting produce in a large market.",
-      "imageUrl": "/images/hero-6.webp",
-      "imageHint": "produce sourcing"
-    },
-    {
-      "id": "hero-7",
-      "description": "A professional setting with a person managing invoices on a laptop.",
-      "imageUrl": "/images/hero-7.webp",
-      "imageHint": "corporate invoicing"
-    },
-    {
-      "id": "hero-8",
-      "description": "A modern display of kitchenware and electronics.",
-      "imageUrl": "/images/hero-8.webp",
-      "imageHint": "kitchenware electronics"
     },
     {
       "id": "gallery-1",


### PR DESCRIPTION
## Summary
- show a single hero image on the home page instead of a rotating carousel
- remove unused hero image placeholders and reference the hero-produce asset

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5947fac8320a188a88fee119618