### PR TITLE
Enhance homepage links with icons and styling

### DIFF
--- a/src/components/pages/home/contact.tsx
+++ b/src/components/pages/home/contact.tsx
@@ -1,6 +1,7 @@
 import { contactDetails } from "@/lib/data";
 import { Card, CardContent } from "@/components/ui/card";
 import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 
 export function Contact() {
   return (
@@ -23,9 +24,16 @@ export function Contact() {
                   <div>
                     <h3 className="font-semibold">{detail.label}</h3>
                     {detail.href ? (
-                       <Link href={detail.href} className="text-muted-foreground hover:text-primary transition-colors whitespace-pre-wrap">
-                          {detail.value}
-                       </Link>
+                      <Link
+                        href={detail.href}
+                        className="group inline-flex items-center gap-2 font-medium text-primary transition-colors hover:text-primary/80 whitespace-pre-wrap"
+                      >
+                        <span>{detail.value}</span>
+                        <ArrowUpRight
+                          className="h-4 w-4 transition-transform group-hover:translate-x-1"
+                          aria-hidden="true"
+                        />
+                      </Link>
                     ) : (
                       <p className="text-muted-foreground">{detail.value}</p>
                     )}

--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { PlaceHolderImages } from "@/lib/placeholder-images";
+import { ShoppingCart, Truck } from "lucide-react";
 
 export function Hero() {
   const heroImage = PlaceHolderImages.find(p => p.id === "hero-produce");
@@ -35,17 +36,23 @@ export function Hero() {
           <Button
             asChild
             size="lg"
-            className="bg-primary hover:bg-primary/90 text-primary-foreground transform transition-transform hover:scale-105"
+            className="bg-primary hover:bg-primary/90 text-primary-foreground transform transition-transform hover:scale-105 group"
           >
-            <Link href="/store">Shop Online</Link>
+            <Link href="/store">
+              <ShoppingCart className="h-5 w-5 transition-transform group-hover:scale-110" aria-hidden="true" />
+              <span>Shop Online</span>
+            </Link>
           </Button>
           <Button
             asChild
             size="lg"
             variant="secondary"
-            className="bg-accent hover:bg-accent/90 text-accent-foreground transform transition-transform hover:scale-105"
+            className="bg-accent hover:bg-accent/90 text-accent-foreground transform transition-transform hover:scale-105 group"
           >
-            <Link href="#wholesale">Wholesale Enquiries</Link>
+            <Link href="#wholesale">
+              <Truck className="h-5 w-5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
+              <span>Wholesale Enquiries</span>
+            </Link>
           </Button>
         </div>
       </div>

--- a/src/components/pages/home/locations.tsx
+++ b/src/components/pages/home/locations.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { locations } from "@/lib/data";
 import Link from "next/link";
-import { MapPin } from "lucide-react";
+import { MapPin, ExternalLink } from "lucide-react";
 
 export function Locations() {
   return (
@@ -37,9 +37,10 @@ export function Locations() {
                 </div>
               </CardContent>
               <div className="p-6 pt-0">
-                <Button asChild className="w-full bg-accent text-accent-foreground hover:bg-accent/90">
+                <Button asChild className="w-full bg-accent text-accent-foreground hover:bg-accent/90 group">
                   <Link href={location.mapLink} target="_blank" rel="noopener noreferrer">
-                    View on Google Maps
+                    <span>View on Google Maps</span>
+                    <ExternalLink className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden="true" />
                   </Link>
                 </Button>
               </div>

--- a/src/components/pages/home/partner-cta.tsx
+++ b/src/components/pages/home/partner-cta.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Handshake } from "lucide-react";
+import { Handshake, ArrowRight } from "lucide-react";
 
 export function PartnerCTA() {
   return (
@@ -15,8 +15,16 @@ export function PartnerCTA() {
             Join us in building healthy, empowered communities. Partner with us to support food security, farmer development, and youth employment in Zimbabwe.
           </p>
           <div className="mt-8">
-            <Button asChild size="lg" style={{ backgroundColor: '#FF9800', color: 'white' }} className="font-bold transform transition-transform hover:scale-105">
-              <Link href="/become-a-partner">Partner With Us</Link>
+            <Button
+              asChild
+              size="lg"
+              style={{ backgroundColor: '#FF9800', color: 'white' }}
+              className="font-bold transform transition-transform hover:scale-105 group"
+            >
+              <Link href="/become-a-partner">
+                <span>Partner With Us</span>
+                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
+              </Link>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add lucide icons to the hero call-to-action buttons and keep hover-friendly motion styling
- decorate the partner and location calls-to-action with directional icons for clearer affordances
- restyle contact links with primary coloring and arrow icons to emphasize interactivity

## Testing
- npm run lint *(fails: ESLint must be installed in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd75cf64508320b129c69e1751e9b7