### PR TITLE
Enhance navigation with labeled icons and update favicon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,8 @@ export const metadata: Metadata = {
   title: "Valley Farm Secrets",
   description: "Freshness. Quality. Convenience. Your farm-to-table partner.",
   icons: {
-    icon: "/images/logo.png",
+    icon: "/favicon.ico",
+    shortcut: "/favicon.ico",
   },
 };
 
@@ -25,7 +26,7 @@ export default function RootLayout({
     href="https://fonts.googleapis.com/css2?family=Alegreya:wght@700&family=Poppins:wght@400;600&display=swap"
     rel="stylesheet"
   />
-  <link rel="icon" href="/images/logo.png" type="image/png" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 </head>
       <body className={cn("font-body antialiased", "min-h-screen bg-background font-sans")}>
         {children}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -37,14 +37,15 @@ export function Header() {
             Valley Farm Secrets
           </span>
         </Link>
-        <nav className="hidden items-center gap-6 md:flex">
+        <nav className="hidden items-center gap-4 md:flex">
           {navLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="text-sm font-medium text-foreground/80 transition-colors hover:text-primary"
+              className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-foreground/80 transition-colors hover:bg-accent/10 hover:text-primary"
             >
-              {link.label}
+              <link.icon aria-hidden="true" className="h-4 w-4" />
+              <span>{link.label}</span>
             </Link>
           ))}
         </nav>
@@ -57,14 +58,14 @@ export function Header() {
               </Button>
             </SheetTrigger>
             <SheetContent side="right" className="w-full max-w-sm bg-background p-0">
-                <SheetTitle className="sr-only">Mobile Menu</SheetTitle>
+              <SheetTitle className="sr-only">Mobile Menu</SheetTitle>
               <div className="flex h-full flex-col">
                 <div className="p-6">
                   <Link href="/" className="flex items-center gap-2" onClick={() => setIsMobileMenuOpen(false)}>
-                      <Logo className="h-7 w-7 text-primary" />
-                      <span className="font-headline text-xl font-bold text-primary">
-                          Valley Farm Secrets
-                      </span>
+                    <Logo className="h-7 w-7 text-primary" />
+                    <span className="font-headline text-xl font-bold text-primary">
+                      Valley Farm Secrets
+                    </span>
                   </Link>
                 </div>
                 <nav className="mt-4 flex flex-col gap-2 p-6 pt-0">
@@ -73,9 +74,10 @@ export function Header() {
                       key={link.href}
                       href={link.href}
                       onClick={() => setIsMobileMenuOpen(false)}
-                      className="rounded-md px-3 py-2 text-lg font-medium text-foreground/80 transition-colors hover:bg-accent/50 hover:text-primary"
+                      className="flex items-center gap-3 rounded-md px-3 py-2 text-lg font-semibold text-foreground/80 transition-colors hover:bg-accent/10 hover:text-primary"
                     >
-                      {link.label}
+                      <link.icon aria-hidden="true" className="h-5 w-5" />
+                      <span>{link.label}</span>
                     </Link>
                   ))}
                 </nav>

--- a/src/lib/nav-links.ts
+++ b/src/lib/nav-links.ts
@@ -1,15 +1,60 @@
+import {
+  Boxes,
+  Cog,
+  Handshake,
+  Images,
+  LucideIcon,
+  MapPin,
+  PhoneCall,
+  ShoppingCart,
+  Sprout,
+} from "lucide-react";
+
 export type NavLink = {
   href: string;
   label: string;
+  icon: LucideIcon;
 };
 
 export const navLinks: NavLink[] = [
-  { href: "/producers", label: "For Producers" },
-  { href: "/become-a-partner", label: "Partner With Us" },
-  { href: "/#services", label: "Services" },
-  { href: "/#locations", label: "Branches" },
-  { href: "/#gallery", label: "Gallery" },
-  { href: "/#wholesale", label: "Wholesale" },
-  { href: "/#contact", label: "Contact Us" },
-  { href: "/store", label: "Online Store" },
+  {
+    href: "/producers",
+    label: "For Producers",
+    icon: Sprout,
+  },
+  {
+    href: "/become-a-partner",
+    label: "Partner With Us",
+    icon: Handshake,
+  },
+  {
+    href: "/#services",
+    label: "Services",
+    icon: Cog,
+  },
+  {
+    href: "/#locations",
+    label: "Branches",
+    icon: MapPin,
+  },
+  {
+    href: "/#gallery",
+    label: "Gallery",
+    icon: Images,
+  },
+  {
+    href: "/#wholesale",
+    label: "Wholesale",
+    icon: Boxes,
+  },
+  {
+    href: "/#contact",
+    label: "Contact Us",
+    icon: PhoneCall,
+  },
+  {
+    href: "/store",
+    label: "Online Store",
+    icon: ShoppingCart,
+  },
 ];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/lib/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     container: {


### PR DESCRIPTION
## Summary
- add lucide icons with neutral styling to the desktop and mobile header navigation links
- extend the shared navigation link configuration with icon metadata and ensure Tailwind scans the library directory
- point site metadata and the head tag at the bundled favicon so the browser tab icon renders reliably

## Testing
- npm run lint *(fails: interactive Next.js ESLint configuration prompt)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd798c4b5c8320a8b0bfed4d4985f1