### PR TITLE
Refine header navigation icons

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -10,6 +10,12 @@ import { navLinks } from "@/lib/nav-links";
 import type { NavLink as NavLinkConfig } from "@/lib/nav-links";
 import { Logo } from "../icons/logo";
 
+const toneClassMap: Record<NavLinkConfig["tone"], string> = {
+  primary: "text-primary",
+  accent: "text-accent",
+  muted: "text-muted-foreground",
+};
+
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -89,6 +95,7 @@ type NavigationLinkItemProps = {
 
 function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemProps) {
   const Icon = link.icon;
+  const toneClass = toneClassMap[link.tone];
 
   return (
     <Link
@@ -103,14 +110,14 @@ function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemPro
         aria-hidden="true"
         className={cn(
           variant === "desktop" ? "h-4 w-4" : "h-5 w-5",
-          "transition-colors group-hover:text-primary",
-          link.colorClass
+          toneClass,
+          "transition-colors group-hover:text-primary group-focus-visible:text-primary"
         )}
       />
       <span
         className={cn(
-          "transition-colors group-hover:text-primary",
-          link.colorClass
+          toneClass,
+          "transition-colors group-hover:text-primary group-focus-visible:text-primary"
         )}
       >
         {link.label}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { navLinks } from "@/lib/nav-links";
+import type { NavLink as NavLinkConfig } from "@/lib/nav-links";
 import { Logo } from "../icons/logo";
 
 export function Header() {
@@ -39,27 +40,7 @@ export function Header() {
         </Link>
         <nav className="hidden items-center gap-4 md:flex">
           {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="group inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition-colors hover:bg-accent/10"
-            >
-              <link.icon
-                aria-hidden="true"
-                className={cn(
-                  "h-4 w-4 transition-colors group-hover:text-primary",
-                  link.colorClass
-                )}
-              />
-              <span
-                className={cn(
-                  "transition-colors group-hover:text-primary",
-                  link.colorClass
-                )}
-              >
-                {link.label}
-              </span>
-            </Link>
+            <NavigationLinkItem key={link.href} link={link} variant="desktop" />
           ))}
         </nav>
         <div className="md:hidden">
@@ -83,28 +64,12 @@ export function Header() {
                 </div>
                 <nav className="mt-4 flex flex-col gap-2 p-6 pt-0">
                   {navLinks.map((link) => (
-                    <Link
+                    <NavigationLinkItem
                       key={link.href}
-                      href={link.href}
-                      onClick={() => setIsMobileMenuOpen(false)}
-                      className="group flex items-center gap-3 rounded-md px-3 py-2 text-lg font-semibold transition-colors hover:bg-accent/10"
-                    >
-                      <link.icon
-                        aria-hidden="true"
-                        className={cn(
-                          "h-5 w-5 transition-colors group-hover:text-primary",
-                          link.colorClass
-                        )}
-                      />
-                      <span
-                        className={cn(
-                          "transition-colors group-hover:text-primary",
-                          link.colorClass
-                        )}
-                      >
-                        {link.label}
-                      </span>
-                    </Link>
+                      link={link}
+                      variant="mobile"
+                      onNavigate={() => setIsMobileMenuOpen(false)}
+                    />
                   ))}
                 </nav>
               </div>
@@ -113,5 +78,43 @@ export function Header() {
         </div>
       </div>
     </header>
+  );
+}
+
+type NavigationLinkItemProps = {
+  link: NavLinkConfig;
+  variant: "desktop" | "mobile";
+  onNavigate?: () => void;
+};
+
+function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemProps) {
+  const Icon = link.icon;
+
+  return (
+    <Link
+      href={link.href}
+      onClick={onNavigate ? () => onNavigate() : undefined}
+      className={cn(
+        "group items-center gap-2 rounded-md px-3 py-2 font-semibold transition-colors hover:bg-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2",
+        variant === "desktop" ? "inline-flex text-sm" : "flex text-lg"
+      )}
+    >
+      <Icon
+        aria-hidden="true"
+        className={cn(
+          variant === "desktop" ? "h-4 w-4" : "h-5 w-5",
+          "transition-colors group-hover:text-primary",
+          link.colorClass
+        )}
+      />
+      <span
+        className={cn(
+          "transition-colors group-hover:text-primary",
+          link.colorClass
+        )}
+      >
+        {link.label}
+      </span>
+    </Link>
   );
 }

--- a/src/lib/nav-links.ts
+++ b/src/lib/nav-links.ts
@@ -10,11 +10,13 @@ import {
   Sprout,
 } from "lucide-react";
 
+export type NavLinkTone = "primary" | "accent" | "muted";
+
 export type NavLink = {
   href: string;
   label: string;
   icon: LucideIcon;
-  colorClass: string;
+  tone: NavLinkTone;
 };
 
 export const navLinks: NavLink[] = [
@@ -22,48 +24,48 @@ export const navLinks: NavLink[] = [
     href: "/producers",
     label: "For Producers",
     icon: Sprout,
-    colorClass: "text-emerald-500",
+    tone: "primary",
   },
   {
     href: "/become-a-partner",
     label: "Partner With Us",
     icon: Handshake,
-    colorClass: "text-sky-500",
+    tone: "accent",
   },
   {
     href: "/#services",
     label: "Services",
     icon: Cog,
-    colorClass: "text-purple-500",
+    tone: "primary",
   },
   {
     href: "/#locations",
     label: "Branches",
     icon: MapPin,
-    colorClass: "text-rose-500",
+    tone: "accent",
   },
   {
     href: "/#gallery",
     label: "Gallery",
     icon: Images,
-    colorClass: "text-amber-500",
+    tone: "muted",
   },
   {
     href: "/#wholesale",
     label: "Wholesale",
     icon: Boxes,
-    colorClass: "text-lime-500",
+    tone: "primary",
   },
   {
     href: "/#contact",
     label: "Contact Us",
     icon: PhoneCall,
-    colorClass: "text-orange-500",
+    tone: "accent",
   },
   {
     href: "/store",
     label: "Online Store",
     icon: ShoppingCart,
-    colorClass: "text-blue-500",
+    tone: "primary",
   },
 ];


### PR DESCRIPTION
## Summary
- replace duplicated desktop and mobile navigation markup with a shared `NavigationLinkItem` helper
- ensure each navigation entry renders its associated Lucide icon with consistent styling and focus states

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfce80b3148320ade2ea63a606ce87