### PR TITLE
Revamp store page with marketplace layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
+import { VallieyAssistant } from "@/components/pages/store/valliey-assistant";
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -30,6 +31,7 @@ export default function RootLayout({
 </head>
       <body className={cn("font-body antialiased", "min-h-screen bg-background font-sans")}>
         {children}
+        <VallieyAssistant />
         <Toaster />
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata } from "next"; 
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { VallieyAssistant } from "@/components/pages/store/valliey-assistant";

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,23 +2,13 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { ArrowRight, ChevronDown, ChevronsLeftRight, Menu } from "lucide-react";
+import { ArrowRight, ChevronDown, ChevronUp, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { navLinks } from "@/lib/nav-links";
 import type { NavLink as NavLinkConfig } from "@/lib/nav-links";
 import { Logo } from "../icons/logo";
-import {
-  Menubar,
-  MenubarContent,
-  MenubarItem,
-  MenubarLabel,
-  MenubarMenu,
-  MenubarSeparator,
-  MenubarTrigger,
-} from "@/components/ui/menubar";
 
 const toneClassMap: Record<NavLinkConfig["tone"], string> = {
   primary: "text-primary",
@@ -26,11 +16,16 @@ const toneClassMap: Record<NavLinkConfig["tone"], string> = {
   muted: "text-muted-foreground",
 };
 
+const toneSurfaceClassMap: Record<NavLinkConfig["tone"], string> = {
+  primary: "bg-primary/15 text-primary",
+  accent: "bg-accent/15 text-accent",
+  muted: "bg-muted/20 text-muted-foreground",
+};
+
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isMenubarOpen, setIsMenubarOpen] = useState(true);
-  const router = useRouter();
+  const [isDesktopNavOpen, setIsDesktopNavOpen] = useState(true);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -49,128 +44,81 @@ export function Header() {
           : "bg-background/80"
       )}
     >
-      <div className="mx-auto flex h-20 w-full max-w-6xl items-center justify-between px-4 md:px-6 lg:px-8">
-        <Link href="/" className="flex items-center gap-2" aria-label="Valley Farm Secrets Home">
-          <Logo className="h-8 w-8 text-primary" />
-          <span className="font-headline text-2xl font-bold text-primary">
-            Valley Farm Secrets
-          </span>
-        </Link>
-        <nav className="hidden items-center gap-3 md:flex">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setIsMenubarOpen((prev) => !prev)}
-            className="flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-primary/5"
-            aria-expanded={isMenubarOpen}
-            aria-controls="primary-menubar"
-          >
-            <ChevronsLeftRight
-              className={cn(
-                "h-4 w-4 transition-transform",
-                isMenubarOpen ? "rotate-0" : "-rotate-180"
-              )}
-            />
-            <span>{isMenubarOpen ? "Fold menu" : "Unfold menu"}</span>
-          </Button>
-          <div
-            className={cn(
-              "overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-in-out",
-              isMenubarOpen ? "max-w-4xl opacity-100 translate-y-0" : "max-w-0 -translate-y-1 opacity-0"
-            )}
-          >
-            <Menubar
-              id="primary-menubar"
-              className="flex h-11 items-center space-x-1 rounded-full border border-border/60 bg-background/85 px-2 shadow-sm backdrop-blur"
+      <div className="mx-auto w-full max-w-6xl px-4 md:px-6 lg:px-8">
+        <div className="flex h-20 items-center justify-between md:h-24">
+          <Link href="/" className="flex items-center gap-2" aria-label="Valley Farm Secrets Home">
+            <Logo className="h-8 w-8 text-primary" />
+            <span className="font-headline text-2xl font-bold text-primary">
+              Valley Farm Secrets
+            </span>
+          </Link>
+          <div className="hidden items-center gap-3 md:flex">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setIsDesktopNavOpen(prev => !prev)}
+              className="flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-primary/5"
+              aria-expanded={isDesktopNavOpen}
+              aria-controls="desktop-navigation"
             >
-              {navLinks.map((link) => {
-                const Icon = link.icon;
-                const toneClass = toneClassMap[link.tone];
-                return (
-                  <MenubarMenu key={link.href}>
-                    <MenubarTrigger
-                      className={cn(
-                        "group flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
-                      )}
-                    >
-                      <Icon
-                        aria-hidden="true"
-                        className={cn(
-                          "h-4 w-4 transition-colors",
-                          toneClass,
-                          "group-hover:text-primary group-focus-visible:text-primary group-data-[state=open]:text-primary"
-                        )}
-                      />
-                      <span
-                        className={cn(
-                          "transition-colors",
-                          toneClass,
-                          "group-hover:text-primary group-focus-visible:text-primary group-data-[state=open]:text-primary"
-                        )}
-                      >
-                        {link.label}
-                      </span>
-                      <ChevronDown
-                        aria-hidden="true"
-                        className="ml-1 h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
-                      />
-                    </MenubarTrigger>
-                    <MenubarContent className="min-w-[14rem] rounded-xl border border-border/70 bg-background/95 p-2 shadow-xl backdrop-blur">
-                      <MenubarLabel className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        <Icon aria-hidden="true" className={cn("h-4 w-4", toneClass)} />
-                        {link.label}
-                      </MenubarLabel>
-                      <MenubarSeparator className="my-2" />
-                      <MenubarItem
-                        onSelect={(event) => {
-                          event.preventDefault();
-                          router.push(link.href);
-                        }}
-                        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-foreground focus:bg-primary/10 focus:text-primary data-[highlighted]:bg-primary/10 data-[highlighted]:text-primary"
-                      >
-                        Visit {link.label}
-                        <ArrowRight aria-hidden="true" className="h-4 w-4 text-primary" />
-                      </MenubarItem>
-                    </MenubarContent>
-                  </MenubarMenu>
-                );
-              })}
-            </Menubar>
+              {isDesktopNavOpen ? (
+                <ChevronUp className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <ChevronDown className="h-4 w-4" aria-hidden="true" />
+              )}
+              <span>{isDesktopNavOpen ? "Hide navigation" : "Browse navigation"}</span>
+            </Button>
           </div>
-        </nav>
-        <div className="md:hidden">
-          <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-                <span className="sr-only">Open menu</span>
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-full max-w-sm bg-background p-0">
-              <SheetTitle className="sr-only">Mobile Menu</SheetTitle>
-              <div className="flex h-full flex-col">
-                <div className="p-6">
-                  <Link href="/" className="flex items-center gap-2" onClick={() => setIsMobileMenuOpen(false)}>
-                    <Logo className="h-7 w-7 text-primary" />
-                    <span className="font-headline text-xl font-bold text-primary">
-                      Valley Farm Secrets
-                    </span>
-                  </Link>
+          <div className="md:hidden">
+            <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <Menu className="h-6 w-6" />
+                  <span className="sr-only">Open menu</span>
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="right" className="w-full max-w-sm bg-background p-0">
+                <SheetTitle className="sr-only">Mobile Menu</SheetTitle>
+                <div className="flex h-full flex-col">
+                  <div className="p-6">
+                    <Link href="/" className="flex items-center gap-2" onClick={() => setIsMobileMenuOpen(false)}>
+                      <Logo className="h-7 w-7 text-primary" />
+                      <span className="font-headline text-xl font-bold text-primary">
+                        Valley Farm Secrets
+                      </span>
+                    </Link>
+                  </div>
+                  <nav className="mt-4 flex flex-col gap-2 p-6 pt-0">
+                    {navLinks.map(link => (
+                      <NavigationLinkItem
+                        key={link.href}
+                        link={link}
+                        variant="mobile"
+                        onNavigate={() => setIsMobileMenuOpen(false)}
+                      />
+                    ))}
+                  </nav>
                 </div>
-                <nav className="mt-4 flex flex-col gap-2 p-6 pt-0">
-                  {navLinks.map((link) => (
-                    <NavigationLinkItem
-                      key={link.href}
-                      link={link}
-                      variant="mobile"
-                      onNavigate={() => setIsMobileMenuOpen(false)}
-                    />
-                  ))}
-                </nav>
-              </div>
-            </SheetContent>
-          </Sheet>
+              </SheetContent>
+            </Sheet>
+          </div>
+        </div>
+        <div
+          id="desktop-navigation"
+          className={cn(
+            "hidden overflow-hidden transition-[max-height,opacity,transform] duration-500 ease-in-out md:block",
+            isDesktopNavOpen
+              ? "pointer-events-auto max-h-[420px] opacity-100 translate-y-0"
+              : "pointer-events-none max-h-0 opacity-0 -translate-y-2"
+          )}
+          aria-hidden={!isDesktopNavOpen}
+        >
+          <nav className="mt-3 grid grid-cols-2 gap-3 rounded-3xl border border-border/60 bg-background/90 p-5 shadow-lg backdrop-blur md:grid-cols-4">
+            {navLinks.map(link => (
+              <NavigationLinkItem key={link.href} link={link} variant="desktop" />
+            ))}
+          </nav>
         </div>
       </div>
     </header>
@@ -187,23 +135,54 @@ function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemPro
   const Icon = link.icon;
   const toneClass = toneClassMap[link.tone];
 
+  if (variant === "desktop") {
+    return (
+      <Link
+        href={link.href}
+        onClick={() => onNavigate?.()}
+        className="group flex h-full items-center justify-between rounded-2xl border border-border/60 bg-background/85 p-5 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <span className="flex items-center gap-4">
+          <span
+            className={cn(
+              "flex h-11 w-11 items-center justify-center rounded-full transition-colors",
+              toneSurfaceClassMap[link.tone]
+            )}
+          >
+            <Icon aria-hidden="true" className="h-5 w-5" />
+          </span>
+          <span
+            className={cn(
+              "text-base font-semibold tracking-tight transition-colors",
+              toneClass,
+              "group-hover:text-primary group-focus-visible:text-primary"
+            )}
+          >
+            {link.label}
+          </span>
+        </span>
+        <ArrowRight
+          aria-hidden="true"
+          className="h-4 w-4 text-muted-foreground transition-all group-hover:translate-x-1 group-hover:text-primary group-focus-visible:translate-x-1 group-focus-visible:text-primary"
+        />
+      </Link>
+    );
+  }
+
   return (
     <Link
       href={link.href}
-      onClick={onNavigate ? () => onNavigate() : undefined}
+      onClick={() => onNavigate?.()}
       className={cn(
-        "group items-center gap-2 rounded-full px-4 py-2 font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-        variant === "desktop"
-          ? "inline-flex text-sm hover:bg-primary/5"
-          : "flex text-lg hover:bg-primary/10"
+        "group flex items-center gap-3 rounded-full border border-border/50 bg-background px-4 py-2 text-base font-medium transition-all hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       )}
     >
       <Icon
         aria-hidden="true"
         className={cn(
-          variant === "desktop" ? "h-4 w-4" : "h-5 w-5",
+          "h-5 w-5 transition-colors",
           toneClass,
-          "transition-colors group-hover:text-primary group-focus-visible:text-primary"
+          "group-hover:text-primary group-focus-visible:text-primary"
         )}
       />
       <span

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,7 +7,14 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { navLinks } from "@/lib/nav-links";
+import type { NavLink as NavLinkConfig } from "@/lib/nav-links";
 import { Logo } from "../icons/logo";
+
+const toneClassMap: Record<NavLinkConfig["tone"], string> = {
+  primary: "text-primary",
+  accent: "text-accent",
+  muted: "text-muted-foreground",
+};
 
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -39,27 +46,7 @@ export function Header() {
         </Link>
         <nav className="hidden items-center gap-4 md:flex">
           {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="group inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition-colors hover:bg-accent/10"
-            >
-              <link.icon
-                aria-hidden="true"
-                className={cn(
-                  "h-4 w-4 transition-colors group-hover:text-primary",
-                  link.colorClass
-                )}
-              />
-              <span
-                className={cn(
-                  "transition-colors group-hover:text-primary",
-                  link.colorClass
-                )}
-              >
-                {link.label}
-              </span>
-            </Link>
+            <NavigationLinkItem key={link.href} link={link} variant="desktop" />
           ))}
         </nav>
         <div className="md:hidden">
@@ -83,28 +70,12 @@ export function Header() {
                 </div>
                 <nav className="mt-4 flex flex-col gap-2 p-6 pt-0">
                   {navLinks.map((link) => (
-                    <Link
+                    <NavigationLinkItem
                       key={link.href}
-                      href={link.href}
-                      onClick={() => setIsMobileMenuOpen(false)}
-                      className="group flex items-center gap-3 rounded-md px-3 py-2 text-lg font-semibold transition-colors hover:bg-accent/10"
-                    >
-                      <link.icon
-                        aria-hidden="true"
-                        className={cn(
-                          "h-5 w-5 transition-colors group-hover:text-primary",
-                          link.colorClass
-                        )}
-                      />
-                      <span
-                        className={cn(
-                          "transition-colors group-hover:text-primary",
-                          link.colorClass
-                        )}
-                      >
-                        {link.label}
-                      </span>
-                    </Link>
+                      link={link}
+                      variant="mobile"
+                      onNavigate={() => setIsMobileMenuOpen(false)}
+                    />
                   ))}
                 </nav>
               </div>
@@ -113,5 +84,44 @@ export function Header() {
         </div>
       </div>
     </header>
+  );
+}
+
+type NavigationLinkItemProps = {
+  link: NavLinkConfig;
+  variant: "desktop" | "mobile";
+  onNavigate?: () => void;
+};
+
+function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemProps) {
+  const Icon = link.icon;
+  const toneClass = toneClassMap[link.tone];
+
+  return (
+    <Link
+      href={link.href}
+      onClick={onNavigate ? () => onNavigate() : undefined}
+      className={cn(
+        "group items-center gap-2 rounded-md px-3 py-2 font-semibold transition-colors hover:bg-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2",
+        variant === "desktop" ? "inline-flex text-sm" : "flex text-lg"
+      )}
+    >
+      <Icon
+        aria-hidden="true"
+        className={cn(
+          variant === "desktop" ? "h-4 w-4" : "h-5 w-5",
+          toneClass,
+          "transition-colors group-hover:text-primary group-focus-visible:text-primary"
+        )}
+      />
+      <span
+        className={cn(
+          toneClass,
+          "transition-colors group-hover:text-primary group-focus-visible:text-primary"
+        )}
+      >
+        {link.label}
+      </span>
+    </Link>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -31,23 +31,25 @@ export function Header() {
   return (
     <header
       className={cn(
-        "sticky top-0 z-50 w-full transition-all duration-300",
+        "sticky top-0 z-50 w-full border-b border-border/40 transition-all duration-300",
         isScrolled
-          ? "bg-background/80 backdrop-blur-sm shadow-md"
-          : "bg-transparent"
+          ? "bg-background/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80"
+          : "bg-background/80"
       )}
     >
-      <div className="container mx-auto flex h-20 items-center justify-between px-4 md:px-6">
+      <div className="mx-auto flex h-20 w-full max-w-6xl items-center justify-between px-4 md:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-2" aria-label="Valley Farm Secrets Home">
           <Logo className="h-8 w-8 text-primary" />
           <span className="font-headline text-2xl font-bold text-primary">
             Valley Farm Secrets
           </span>
         </Link>
-        <nav className="hidden items-center gap-4 md:flex">
-          {navLinks.map((link) => (
-            <NavigationLinkItem key={link.href} link={link} variant="desktop" />
-          ))}
+        <nav className="hidden md:flex">
+          <div className="flex items-center gap-1 rounded-full border border-border/60 bg-background/80 px-2 py-1 shadow-sm backdrop-blur">
+            {navLinks.map((link) => (
+              <NavigationLinkItem key={link.href} link={link} variant="desktop" />
+            ))}
+          </div>
         </nav>
         <div className="md:hidden">
           <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
@@ -102,8 +104,10 @@ function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemPro
       href={link.href}
       onClick={onNavigate ? () => onNavigate() : undefined}
       className={cn(
-        "group items-center gap-2 rounded-md px-3 py-2 font-semibold transition-colors hover:bg-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2",
-        variant === "desktop" ? "inline-flex text-sm" : "flex text-lg"
+        "group items-center gap-2 rounded-full px-4 py-2 font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        variant === "desktop"
+          ? "inline-flex text-sm hover:bg-primary/5"
+          : "flex text-lg hover:bg-primary/10"
       )}
     >
       <Icon

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,13 +2,23 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, ChevronDown, ChevronsLeftRight, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { navLinks } from "@/lib/nav-links";
 import type { NavLink as NavLinkConfig } from "@/lib/nav-links";
 import { Logo } from "../icons/logo";
+import {
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarLabel,
+  MenubarMenu,
+  MenubarSeparator,
+  MenubarTrigger,
+} from "@/components/ui/menubar";
 
 const toneClassMap: Record<NavLinkConfig["tone"], string> = {
   primary: "text-primary",
@@ -19,6 +29,8 @@ const toneClassMap: Record<NavLinkConfig["tone"], string> = {
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isMenubarOpen, setIsMenubarOpen] = useState(true);
+  const router = useRouter();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -44,11 +56,87 @@ export function Header() {
             Valley Farm Secrets
           </span>
         </Link>
-        <nav className="hidden md:flex">
-          <div className="flex items-center gap-1 rounded-full border border-border/60 bg-background/80 px-2 py-1 shadow-sm backdrop-blur">
-            {navLinks.map((link) => (
-              <NavigationLinkItem key={link.href} link={link} variant="desktop" />
-            ))}
+        <nav className="hidden items-center gap-3 md:flex">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setIsMenubarOpen((prev) => !prev)}
+            className="flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-primary/5"
+            aria-expanded={isMenubarOpen}
+            aria-controls="primary-menubar"
+          >
+            <ChevronsLeftRight
+              className={cn(
+                "h-4 w-4 transition-transform",
+                isMenubarOpen ? "rotate-0" : "-rotate-180"
+              )}
+            />
+            <span>{isMenubarOpen ? "Fold menu" : "Unfold menu"}</span>
+          </Button>
+          <div
+            className={cn(
+              "overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-in-out",
+              isMenubarOpen ? "max-w-4xl opacity-100 translate-y-0" : "max-w-0 -translate-y-1 opacity-0"
+            )}
+          >
+            <Menubar
+              id="primary-menubar"
+              className="flex h-11 items-center space-x-1 rounded-full border border-border/60 bg-background/85 px-2 shadow-sm backdrop-blur"
+            >
+              {navLinks.map((link) => {
+                const Icon = link.icon;
+                const toneClass = toneClassMap[link.tone];
+                return (
+                  <MenubarMenu key={link.href}>
+                    <MenubarTrigger
+                      className={cn(
+                        "group flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
+                      )}
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        className={cn(
+                          "h-4 w-4 transition-colors",
+                          toneClass,
+                          "group-hover:text-primary group-focus-visible:text-primary group-data-[state=open]:text-primary"
+                        )}
+                      />
+                      <span
+                        className={cn(
+                          "transition-colors",
+                          toneClass,
+                          "group-hover:text-primary group-focus-visible:text-primary group-data-[state=open]:text-primary"
+                        )}
+                      >
+                        {link.label}
+                      </span>
+                      <ChevronDown
+                        aria-hidden="true"
+                        className="ml-1 h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+                      />
+                    </MenubarTrigger>
+                    <MenubarContent className="min-w-[14rem] rounded-xl border border-border/70 bg-background/95 p-2 shadow-xl backdrop-blur">
+                      <MenubarLabel className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <Icon aria-hidden="true" className={cn("h-4 w-4", toneClass)} />
+                        {link.label}
+                      </MenubarLabel>
+                      <MenubarSeparator className="my-2" />
+                      <MenubarItem
+                        onSelect={(event) => {
+                          event.preventDefault();
+                          router.push(link.href);
+                        }}
+                        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-foreground focus:bg-primary/10 focus:text-primary data-[highlighted]:bg-primary/10 data-[highlighted]:text-primary"
+                      >
+                        Visit {link.label}
+                        <ArrowRight aria-hidden="true" className="h-4 w-4 text-primary" />
+                      </MenubarItem>
+                    </MenubarContent>
+                  </MenubarMenu>
+                );
+              })}
+            </Menubar>
           </div>
         </nav>
         <div className="md:hidden">

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -16,7 +16,6 @@ const toneClassMap: Record<NavLinkConfig["tone"], string> = {
   muted: "text-muted-foreground",
 };
 
-main
 export function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -39,7 +38,14 @@ export function Header() {
           : "bg-background/80"
       )}
     >
-main
+      {/* Assuming there was content for the header here that was accidentally deleted or replaced by 'main' */}
+      <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-6">
+        <div className="flex items-center gap-6">
+          <Link href="/" className="flex items-center gap-2" onClick={() => setIsMobileMenuOpen(false)}>
+            <Logo className="h-8 w-8" />
+            <span className="sr-only">Home</span>
+          </Link>
+          {/* ... other header content */}
         </div>
       </div>
     </header>
@@ -56,13 +62,51 @@ function NavigationLinkItem({ link, variant, onNavigate }: NavigationLinkItemPro
   const Icon = link.icon;
   const toneClass = toneClassMap[link.tone];
 
-main
+  if (link.href.startsWith("http")) {
+    return (
+      <a
+        href={link.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onNavigate}
+        className={cn(
+          "group flex items-center gap-3 rounded-md p-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          variant === "desktop" ? "hover:bg-muted/60" : "hover:bg-muted"
+        )}
+      >
+        <Icon
+          aria-hidden="true"
+          className={cn(
+            "h-5 w-5 transition-colors group-hover:text-primary group-focus-visible:text-primary",
+            toneClass
+          )}
+        />
+        <span
+          className={cn(
+            toneClass,
+            "transition-colors group-hover:text-primary group-focus-visible:text-primary"
+          )}
+        >
+          {link.label}
+        </span>
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      href={link.href}
+      onClick={onNavigate}
+      className={cn(
+        "group flex items-center gap-3 rounded-md p-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        variant === "desktop" ? "hover:bg-muted/60" : "hover:bg-muted"
       )}
     >
       <Icon
         aria-hidden="true"
         className={cn(
-main
+          "h-5 w-5 transition-colors group-hover:text-primary group-focus-visible:text-primary",
+          toneClass
         )}
       />
       <span

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -20,6 +20,7 @@ import {
   Sparkle,
   Zap,
 } from "lucide-react";
+import { useState, useMemo, useCallback, useRef } from "react"; 
 
 export type SortOption = "name-asc" | "name-desc" | "price-asc" | "price-desc";
 

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import { products, categories, Category } from "@/app/store/data";
+// Add PlaceHolderImages to this import line
+import { products, categories, Category, PlaceHolderImages } from "@/app/store/data";
 import ProductFilters from "./product-filters";
 import ProductGrid from "./product-grid";
 import { ShoppingCart } from "./shopping-cart";

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -1,36 +1,123 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
-import { products, categories, Category } from '@/app/store/data';
-import ProductFilters from './product-filters';
-import ProductGrid from './product-grid';
-import { ShoppingCart } from './shopping-cart';
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
-import ProductCard from './product-card';
+import Image from "next/image";
+import React, { useMemo, useRef, useState, useCallback } from "react";
+import { products, categories, Category } from "@/app/store/data";
+import ProductFilters from "./product-filters";
+import ProductGrid from "./product-grid";
+import { ShoppingCart } from "./shopping-cart";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+import ProductCard from "./product-card";
+import { PlaceHolderImages } from "@/lib/placeholder-images";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { services } from "@/lib/data";
+import {
+  type LucideIcon,
+  Carrot,
+  Beef,
+  ShoppingBasket,
+  Sparkle,
+  Zap,
+  Truck,
+  Clock,
+} from "lucide-react";
+import { VallieyAssistant } from "./valliey-assistant";
 
 export type SortOption = "name-asc" | "name-desc" | "price-asc" | "price-desc";
+
+type HeroSlide = {
+  imageId: string;
+  title: string;
+  description: string;
+  highlight: string;
+  category: Category;
+  cta: string;
+};
+
+type QuickTile = {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  action?: {
+    label: string;
+    onClick?: () => void;
+    href?: string;
+  };
+  footer?: string;
+};
+
+const categoryIcons: Record<Category, LucideIcon> = {
+  "Fruit & Veg": Carrot,
+  "Butchery": Beef,
+  "Grocery & Spices": ShoppingBasket,
+};
 
 export function StoreLayout() {
   const [searchTerm, setSearchTerm] = useState("");
   const [showSpecialsOnly, setShowSpecialsOnly] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<Category | "All">("All");
   const [sortOption, setSortOption] = useState<SortOption>("name-asc");
-  
-  const specialOffers = useMemo(() => products.filter(p => p.onSpecial), []);
+  const productSectionRef = useRef<HTMLDivElement | null>(null);
+
+  const specialOffers = useMemo(() => products.filter(product => product.onSpecial), []);
+
+  const heroSlides = useMemo(() => {
+    const slides: HeroSlide[] = [
+      {
+        imageId: "hero-produce",
+        title: "Fresh Market Arrivals",
+        description: "Hand-picked vegetables, crisp greens, and seasonal fruits landing in store daily.",
+        highlight: "Up to 25% off farm-fresh staples",
+        category: "Fruit & Veg",
+        cta: "Shop fresh produce",
+      },
+      {
+        imageId: "gallery-2",
+        title: "Master Butchery Cuts",
+        description: "Premium beef, lamb, chicken, and braai packs prepared by our in-house butchers.",
+        highlight: "Bundle deals for the weekend braai",
+        category: "Butchery",
+        cta: "Explore the butchery",
+      },
+      {
+        imageId: "gallery-4",
+        title: "Pantry & Spice World",
+        description: "Stock your shelves with Valley Farm Secrets groceries, spice blends, and everyday essentials.",
+        highlight: "Wholesale-ready pack sizes",
+        category: "Grocery & Spices",
+        cta: "Browse groceries",
+      },
+    ];
+
+    return slides.map(slide => ({
+      ...slide,
+      image: PlaceHolderImages.find(image => image.id === slide.imageId) ?? null,
+    }));
+  }, []);
 
   const filteredAndSortedProducts = useMemo(() => {
     let filtered = [...products];
 
     if (showSpecialsOnly) {
-      filtered = filtered.filter(p => p.onSpecial);
+      filtered = filtered.filter(product => product.onSpecial);
     }
 
     if (selectedCategory !== "All") {
-      filtered = filtered.filter(p => p.category === selectedCategory);
+      filtered = filtered.filter(product => product.category === selectedCategory);
     }
 
     if (searchTerm) {
-      filtered = filtered.filter(p => p.name.toLowerCase().includes(searchTerm.toLowerCase()));
+      filtered = filtered.filter(product =>
+        product.name.toLowerCase().includes(searchTerm.toLowerCase()),
+      );
     }
 
     return filtered.sort((a, b) => {
@@ -51,53 +138,284 @@ export function StoreLayout() {
 
   const hasActiveFilter = Boolean(searchTerm) || showSpecialsOnly || selectedCategory !== "All";
 
+  const handleCategorySelect = useCallback((category: Category | "All") => {
+    setSelectedCategory(category);
+    setShowSpecialsOnly(false);
+    productSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  const handleViewSpecials = useCallback(() => {
+    setShowSpecialsOnly(true);
+    productSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  const highlightServices = services.filter(service =>
+    [
+      "Fruit & Vegetables",
+      "Butchery",
+      "Grocery & Spices",
+      "Wholesale Supply",
+    ].includes(service.title),
+  );
+
+  const quickTiles: QuickTile[] = [
+    {
+      title: "Flash Deals",
+      description: "Limited-time savings refreshed weekly across all departments.",
+      icon: Zap,
+      action: {
+        label: "View specials",
+        onClick: handleViewSpecials,
+      },
+    },
+    {
+      title: "Wholesale Desk",
+      description: "Bulk pricing, deliveries, and standing orders for institutions & restaurants.",
+      icon: Truck,
+      action: {
+        label: "Call +263 788 679 000",
+        href: "tel:+263788679000",
+      },
+    },
+    {
+      title: "Store Hours",
+      description: "Mon-Sat: 8:00 AM - 7:00 PM",
+      icon: Clock,
+      footer: "Visit us at 75 Main Street, Gweru.",
+    },
+  ];
+
   return (
-    <div className="container mx-auto px-4 md:px-6 py-8">
+    <div className="bg-muted/10 pb-16">
       <ShoppingCart />
-      {/* Special Offers Carousel */}
-      <section className="mb-12">
-        <h2 className="font-headline text-3xl font-bold mb-4">Special Offers</h2>
-        <Carousel opts={{ align: "start", loop: true }} className="w-full">
-          <CarouselContent>
-            {specialOffers.map(product => (
-              <CarouselItem key={product.id} className="md:basis-1/2 lg:basis-1/3 xl:basis-1/4">
-                <div className="p-1">
-                  <ProductCard product={product} />
+
+      <section className="border-b bg-gradient-to-br from-primary/10 via-background to-background py-10 lg:py-14">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)_280px] xl:grid-cols-[260px_minmax(0,1fr)_320px]">
+            <aside className="hidden h-full rounded-2xl border bg-card/70 backdrop-blur lg:block">
+              <div className="border-b px-6 py-5">
+                <h3 className="font-headline text-lg font-semibold">Shop by Department</h3>
+                <p className="mt-1 text-sm text-muted-foreground">Browse categories just like the store aisles.</p>
+              </div>
+              <nav className="flex flex-col divide-y">
+                <button
+                  type="button"
+                  onClick={() => handleCategorySelect("All")}
+                  className={`flex items-center gap-3 px-6 py-3 text-left text-sm font-medium transition-colors hover:bg-muted/60 ${selectedCategory === "All" ? "bg-primary text-primary-foreground" : "text-foreground"}`}
+                >
+                  <Sparkle className="h-4 w-4" />
+                  View everything
+                </button>
+                {categories.map(category => {
+                  const Icon = categoryIcons[category];
+                  const isActive = selectedCategory === category;
+                  return (
+                    <button
+                      key={category}
+                      type="button"
+                      onClick={() => handleCategorySelect(category)}
+                      className={`flex items-center gap-3 px-6 py-3 text-left text-sm font-medium transition-colors hover:bg-muted/60 ${isActive ? "bg-primary text-primary-foreground" : "text-foreground"}`}
+                    >
+                      {Icon && <Icon className="h-4 w-4" />}
+                      {category}
+                    </button>
+                  );
+                })}
+              </nav>
+            </aside>
+
+            <div className="space-y-5">
+              <div className="lg:hidden">
+                <div className="flex gap-3 overflow-x-auto pb-2">
+                  {["All", ...categories].map(category => {
+                    const isActive = selectedCategory === category;
+                    return (
+                      <Button
+                        key={category}
+                        size="sm"
+                        variant={isActive ? "default" : "outline"}
+                        className="whitespace-nowrap"
+                        onClick={() => handleCategorySelect(category as Category | "All")}
+                      >
+                        {category}
+                      </Button>
+                    );
+                  })}
                 </div>
-              </CarouselItem>
-            ))}
-          </CarouselContent>
-          <CarouselPrevious className="ml-12" />
-          <CarouselNext className="mr-12" />
-        </Carousel>
+              </div>
+
+              <Carousel opts={{ loop: true }} className="overflow-hidden rounded-2xl">
+                <CarouselContent>
+                  {heroSlides.map(slide => (
+                    <CarouselItem key={slide.imageId}>
+                      <div className="relative h-[260px] overflow-hidden rounded-2xl bg-muted sm:h-[320px] lg:h-[360px]">
+                        {slide.image && (
+                          <Image
+                            src={slide.image.imageUrl}
+                            alt={slide.image.description}
+                            fill
+                            className="object-cover"
+                            priority
+                            sizes="(min-width: 1280px) 960px, (min-width: 768px) 70vw, 90vw"
+                            data-ai-hint={slide.image.imageHint}
+                          />
+                        )}
+                        <div className="absolute inset-0 bg-gradient-to-r from-background/90 via-background/70 to-background/10" />
+                        <div className="relative z-10 flex h-full flex-col justify-center gap-4 px-7 py-8 sm:px-10">
+                          <Badge className="w-fit bg-primary text-primary-foreground shadow">{slide.highlight}</Badge>
+                          <h2 className="font-headline text-3xl font-bold text-foreground sm:text-4xl">{slide.title}</h2>
+                          <p className="max-w-xl text-sm text-muted-foreground sm:text-base">{slide.description}</p>
+                          <div className="flex flex-wrap items-center gap-3">
+                            <Button size="lg" onClick={() => handleCategorySelect(slide.category)}>
+                              {slide.cta}
+                            </Button>
+                            <Button variant="outline" size="lg" onClick={handleViewSpecials}>
+                              See specials
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+                <CarouselPrevious className="left-4 top-1/2 hidden h-10 w-10 -translate-y-1/2 rounded-full bg-background/90 shadow lg:flex" />
+                <CarouselNext className="right-4 top-1/2 hidden h-10 w-10 -translate-y-1/2 rounded-full bg-background/90 shadow lg:flex" />
+              </Carousel>
+
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                {highlightServices.map(service => (
+                  <Card key={service.title} className="border-none bg-card/80 shadow-sm">
+                    <CardHeader className="flex flex-row items-center gap-3 pb-2">
+                      <div className="rounded-full bg-primary/10 p-3 text-primary">
+                        <service.icon className="h-5 w-5" />
+                      </div>
+                      <CardTitle className="text-base font-semibold">{service.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="pt-0 text-sm text-muted-foreground">{service.description}</CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+
+            <div className="hidden flex-col gap-4 lg:flex">
+              {quickTiles.map(tile => (
+                <Card key={tile.title} className="h-full border border-border/60 bg-card/80 shadow-sm">
+                  <CardHeader className="flex flex-row items-center gap-3 pb-3">
+                    <div className="rounded-full bg-primary/10 p-3 text-primary">
+                      <tile.icon className="h-5 w-5" />
+                    </div>
+                    <CardTitle className="text-base font-semibold">{tile.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex flex-col gap-4 text-sm text-muted-foreground">
+                    <p>{tile.description}</p>
+                    {tile.action ? (
+                      tile.action.href ? (
+                        <Button size="sm" variant="outline" asChild>
+                          <a href={tile.action.href} onClick={tile.action.onClick}>
+                            {tile.action.label}
+                          </a>
+                        </Button>
+                      ) : tile.action.onClick ? (
+                        <Button size="sm" onClick={tile.action.onClick}>
+                          {tile.action.label}
+                        </Button>
+                      ) : (
+                        <p className="text-sm font-medium text-primary">{tile.action.label}</p>
+                      )
+                    ) : tile.footer ? (
+                      <p className="text-sm font-medium text-primary">{tile.footer}</p>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </div>
       </section>
 
-      {/* Main Store Layout */}
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
-        {/* Sidebar */}
-        <aside className="lg:col-span-1">
-          <ProductFilters
-            searchTerm={searchTerm}
-            setSearchTerm={setSearchTerm}
-            showSpecialsOnly={showSpecialsOnly}
-            setShowSpecialsOnly={setShowSpecialsOnly}
-            selectedCategory={selectedCategory}
-            setSelectedCategory={setSelectedCategory}
-            categories={categories}
-          />
-        </aside>
-
-        {/* Main Content */}
-        <div className="lg:col-span-3">
-          <ProductGrid
-            products={filteredAndSortedProducts}
-            sortOption={sortOption}
-            setSortOption={setSortOption}
-            hasActiveFilter={hasActiveFilter}
-            categories={categories}
-          />
+      <section id="flash-deals" className="container mx-auto px-4 pb-12 pt-10 md:px-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="font-headline text-2xl font-bold md:text-3xl">Flash Deals</h2>
+            <p className="text-muted-foreground">Catch the latest promotions before they sell out.</p>
+          </div>
+          <Button variant="ghost" onClick={handleViewSpecials}>
+            Shop all specials
+          </Button>
         </div>
-      </div>
+        <div className="mt-6">
+          {specialOffers.length > 0 ? (
+            <Carousel opts={{ align: "start", loop: true }} className="w-full">
+              <CarouselContent>
+                {specialOffers.map(product => (
+                  <CarouselItem key={product.id} className="sm:basis-1/2 lg:basis-1/3 xl:basis-1/4">
+                    <div className="p-1">
+                      <ProductCard product={product} />
+                    </div>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious className="left-4 top-1/2 hidden h-10 w-10 -translate-y-1/2 rounded-full bg-background/90 shadow md:flex" />
+              <CarouselNext className="right-4 top-1/2 hidden h-10 w-10 -translate-y-1/2 rounded-full bg-background/90 shadow md:flex" />
+            </Carousel>
+          ) : (
+            <p className="rounded-lg border bg-card/60 p-8 text-center text-muted-foreground">
+              New deals are loading — check back soon!
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section id="store-services" className="bg-card/40 py-14">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="font-headline text-3xl font-bold md:text-4xl">In-Store Services & Departments</h2>
+            <p className="mt-3 text-base text-muted-foreground">
+              Everything you can access when you walk through our doors — from retail counters to wholesale support and corporate servicing.
+            </p>
+          </div>
+          <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {services.map(service => (
+              <Card key={service.title} className="h-full border-none bg-background/90 shadow-sm">
+                <CardHeader className="flex flex-col items-start gap-3">
+                  <div className="rounded-full bg-primary/10 p-3 text-primary">
+                    <service.icon className="h-6 w-6" />
+                  </div>
+                  <CardTitle className="text-lg font-semibold">{service.title}</CardTitle>
+                </CardHeader>
+                <CardContent className="pt-0 text-sm text-muted-foreground">{service.description}</CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section ref={productSectionRef} id="store-products" className="container mx-auto px-4 pb-16 pt-12 md:px-6">
+        <div className="grid gap-8 lg:grid-cols-[280px_minmax(0,1fr)]">
+          <div className="order-2 space-y-6 lg:order-1">
+            <ProductFilters
+              searchTerm={searchTerm}
+              setSearchTerm={setSearchTerm}
+              showSpecialsOnly={showSpecialsOnly}
+              setShowSpecialsOnly={setShowSpecialsOnly}
+              selectedCategory={selectedCategory}
+              setSelectedCategory={setSelectedCategory}
+              categories={categories}
+            />
+          </div>
+
+          <div className="order-1 lg:order-2">
+            <ProductGrid
+              products={filteredAndSortedProducts}
+              sortOption={sortOption}
+              setSortOption={setSortOption}
+              hasActiveFilter={hasActiveFilter}
+              categories={categories}
+            />
+          </div>
+        </div>
+      </section>
+      <VallieyAssistant />
     </div>
   );
 }

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-main
 import { products, categories, Category } from "@/app/store/data";
 import ProductFilters from "./product-filters";
 import ProductGrid from "./product-grid";
@@ -14,14 +13,12 @@ import {
   CarouselPrevious,
 } from "@/components/ui/carousel";
 import ProductCard from "./product-card";
-
-main
+import {
   Carrot,
   Beef,
   ShoppingBasket,
   Sparkle,
   Zap,
-main
 } from "lucide-react";
 
 export type SortOption = "name-asc" | "name-desc" | "price-asc" | "price-desc";
@@ -35,7 +32,6 @@ type HeroSlide = {
   cta: string;
 };
 
-main
 type QuickTile = {
   title: string;
   description: string;
@@ -48,7 +44,6 @@ type QuickTile = {
   footer?: string;
 };
 
-main
 const categoryIcons: Record<Category, LucideIcon> = {
   "Fruit & Veg": Carrot,
   "Butchery": Beef,
@@ -64,7 +59,7 @@ export function StoreLayout() {
 
   const specialOffers = useMemo(() => products.filter(product => product.onSpecial), []);
 
- main
+  const heroSlides = useMemo(() => {
     const slides: HeroSlide[] = [
       {
         imageId: "hero-produce",
@@ -97,7 +92,6 @@ export function StoreLayout() {
       image: PlaceHolderImages.find(image => image.id === slide.imageId) ?? null,
     }));
   }, []);
- main
 
   const filteredAndSortedProducts = useMemo(() => {
     let filtered = [...products];
@@ -145,9 +139,6 @@ export function StoreLayout() {
     productSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
-
-main
-
   const quickTiles: QuickTile[] = [
     {
       title: "Flash Deals",
@@ -159,12 +150,12 @@ main
       },
     },
     {
-main
+      // This object was incomplete in your provided code, you might need to fill it
     },
   ];
 
   return (
-    <div Name="bg-muted/10 pb-16">
+    <div className="bg-muted/10 pb-16">
       <ShoppingCart />
 
       <section className="border-b bg-gradient-to-br from-primary/10 via-background to-background py-10 lg:py-14">
@@ -219,8 +210,7 @@ main
                       </Button>
                     );
                   })}
-
-main
+                </div>
               </div>
             </div>
 
@@ -258,7 +248,6 @@ main
             </div>
           </div>
         </div>
- main
       </section>
     </div>
   );

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -27,7 +27,6 @@ import {
   Sparkle,
   Zap,
 } from "lucide-react";
-import { VallieyAssistant } from "./valliey-assistant";
 
 export type SortOption = "name-asc" | "name-desc" | "price-asc" | "price-desc";
 
@@ -509,7 +508,6 @@ export function StoreLayout() {
           </div>
         </div>
       </section>
-      <VallieyAssistant />
     </div>
   );
 }

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -119,9 +119,7 @@ export function StoreLayout() {
     }));
   }, []);
 
-  const [activeHeroIndex, setActiveHeroIndex] = useState(() =>
-    heroSlides.length > 0 ? Math.floor(Math.random() * heroSlides.length) : 0
-  );
+  const [activeHeroIndex, setActiveHeroIndex] = useState(0);
 
   useEffect(() => {
     if (heroSlides.length <= 1) {
@@ -129,17 +127,11 @@ export function StoreLayout() {
     }
 
     const rotation = window.setInterval(() => {
-      setActiveHeroIndex(prevIndex => {
-        let nextIndex = Math.floor(Math.random() * heroSlides.length);
-        if (nextIndex === prevIndex) {
-          nextIndex = (nextIndex + 1) % heroSlides.length;
-        }
-        return nextIndex;
-      });
+      setActiveHeroIndex(prevIndex => (prevIndex + 1) % heroSlides.length);
     }, 7000);
 
     return () => window.clearInterval(rotation);
-  }, [heroSlides, heroSlides.length]);
+  }, [heroSlides.length]);
 
   const currentHeroSlide = heroSlides[activeHeroIndex] ?? heroSlides[0];
 
@@ -339,6 +331,7 @@ export function StoreLayout() {
                       <div
                         key={slide.imageId}
                         className={`${isActive ? "opacity-100" : "opacity-0"} absolute inset-0 bg-muted transition-opacity duration-700`}
+                        aria-hidden={!isActive}
                       />
                     );
                   }
@@ -349,14 +342,15 @@ export function StoreLayout() {
                       src={slide.image.imageUrl}
                       alt={slide.image.description}
                       fill
-                      className={`${isActive ? "opacity-100" : "opacity-0"} object-cover transition-opacity duration-700`}
+                      className={`${isActive ? "opacity-100" : "opacity-0"} absolute inset-0 h-full w-full object-cover transition-opacity duration-700`}
                       priority={isActive}
                       sizes="(min-width: 1280px) 960px, (min-width: 768px) 70vw, 90vw"
                       data-ai-hint={slide.image.imageHint}
+                      aria-hidden={!isActive}
                     />
                   );
                 })}
-                <div className="absolute inset-0 bg-gradient-to-r from-background/90 via-background/70 to-background/10" />
+                <div className="absolute inset-0 bg-gradient-to-r from-background/75 via-background/40 to-transparent" />
                 <div className="relative z-10 flex h-full flex-col justify-center gap-4 px-7 py-8 sm:px-10">
                   {currentHeroSlide && (
                     <>

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -18,16 +18,14 @@ import { PlaceHolderImages } from "@/lib/placeholder-images";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { services } from "@/lib/data";
 import {
   type LucideIcon,
+  ArrowRight,
   Carrot,
   Beef,
   ShoppingBasket,
   Sparkle,
   Zap,
-  Truck,
-  Clock,
 } from "lucide-react";
 import { VallieyAssistant } from "./valliey-assistant";
 
@@ -52,6 +50,21 @@ type QuickTile = {
     href?: string;
   };
   footer?: string;
+};
+
+type CategorySpotlight = {
+  title: string;
+  description: string;
+  category: Category;
+  cta: string;
+};
+
+type ShoppingCollection = {
+  title: string;
+  description: string;
+  category: Category;
+  highlights: string[];
+  cta: string;
 };
 
 const categoryIcons: Record<Category, LucideIcon> = {
@@ -149,14 +162,57 @@ export function StoreLayout() {
     productSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
-  const highlightServices = services.filter(service =>
-    [
-      "Fruit & Vegetables",
-      "Butchery",
-      "Grocery & Spices",
-      "Wholesale Supply",
-    ].includes(service.title),
-  );
+  const categorySpotlights: CategorySpotlight[] = [
+    {
+      title: "Meal Prep Veggie Boxes",
+      description: "Seasonal greens and fruit crates packed for weekly meal plans.",
+      category: "Fruit & Veg",
+      cta: "Shop fresh produce",
+    },
+    {
+      title: "Butcher's Signature Cuts",
+      description: "Premium steaks, sausages, and braai favourites ready for the grill.",
+      category: "Butchery",
+      cta: "Shop butchery deals",
+    },
+    {
+      title: "Pantry Power-Ups",
+      description: "Top up essentials, spices, and breakfast favourites in one go.",
+      category: "Grocery & Spices",
+      cta: "Restock the pantry",
+    },
+  ];
+
+  const shoppingCollections: ShoppingCollection[] = [
+    {
+      title: "Family Braai Night",
+      description: "Build a basket with rump steak, boerewors, and spicy condiments for the perfect weekend fire.",
+      category: "Butchery",
+      highlights: ["Premium cuts", "Bulk packs", "Marinades"],
+      cta: "Shop braai essentials",
+    },
+    {
+      title: "Fresh Market Staples",
+      description: "Fill your cart with leafy greens, crunchy veg, and sweet fruit for smoothies and salads.",
+      category: "Fruit & Veg",
+      highlights: ["Seasonal picks", "Ready-to-eat", "Juice-friendly"],
+      cta: "Explore produce crates",
+    },
+    {
+      title: "Pantry Restock",
+      description: "Grab breads, spices, and breakfast must-haves with multi-buy savings.",
+      category: "Grocery & Spices",
+      highlights: ["Everyday basics", "Bulk savings", "Breakfast wins"],
+      cta: "Fill the pantry",
+    },
+    {
+      title: "Quick Midweek Fix",
+      description: "Mix and match protein, veg, and sauces for fast dinners without the guesswork.",
+      category: "Butchery",
+      highlights: ["Ready in minutes", "Chef-curated", "Family friendly"],
+      cta: "Shop midweek combos",
+    },
+  ];
 
   const quickTiles: QuickTile[] = [
     {
@@ -169,19 +225,22 @@ export function StoreLayout() {
       },
     },
     {
-      title: "Wholesale Desk",
-      description: "Bulk pricing, deliveries, and standing orders for institutions & restaurants.",
-      icon: Truck,
+      title: "Produce Bundles",
+      description: "Curated boxes of seasonal fruit and veg pre-packed for easy checkout.",
+      icon: Carrot,
       action: {
-        label: "Call +263 788 679 000",
-        href: "tel:+263788679000",
+        label: "Shop fresh boxes",
+        onClick: () => handleCategorySelect("Fruit & Veg"),
       },
     },
     {
-      title: "Store Hours",
-      description: "Mon-Sat: 8:00 AM - 7:00 PM",
-      icon: Clock,
-      footer: "Visit us at 75 Main Street, Gweru.",
+      title: "Pantry Restock",
+      description: "Top up breakfast, baking, and spice essentials with multi-buy offers.",
+      icon: ShoppingBasket,
+      action: {
+        label: "Fill the pantry",
+        onClick: () => handleCategorySelect("Grocery & Spices"),
+      },
     },
   ];
 
@@ -283,17 +342,31 @@ export function StoreLayout() {
               </Carousel>
 
               <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-                {highlightServices.map(service => (
-                  <Card key={service.title} className="border-none bg-card/80 shadow-sm">
-                    <CardHeader className="flex flex-row items-center gap-3 pb-2">
-                      <div className="rounded-full bg-primary/10 p-3 text-primary">
-                        <service.icon className="h-5 w-5" />
-                      </div>
-                      <CardTitle className="text-base font-semibold">{service.title}</CardTitle>
-                    </CardHeader>
-                    <CardContent className="pt-0 text-sm text-muted-foreground">{service.description}</CardContent>
-                  </Card>
-                ))}
+                {categorySpotlights.map(spotlight => {
+                  const Icon = categoryIcons[spotlight.category];
+                  return (
+                    <Card key={spotlight.title} className="border-none bg-card/80 shadow-sm">
+                      <CardHeader className="flex flex-row items-center gap-3 pb-2">
+                        <div className="rounded-full bg-primary/10 p-3 text-primary">
+                          {Icon && <Icon className="h-5 w-5" />}
+                        </div>
+                        <CardTitle className="text-base font-semibold">{spotlight.title}</CardTitle>
+                      </CardHeader>
+                      <CardContent className="pt-0 text-sm text-muted-foreground">
+                        <p>{spotlight.description}</p>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="mt-3 w-fit gap-1 px-0 text-primary hover:bg-transparent"
+                          onClick={() => handleCategorySelect(spotlight.category)}
+                        >
+                          {spotlight.cta}
+                          <ArrowRight className="h-4 w-4" />
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
               </div>
             </div>
 
@@ -366,26 +439,47 @@ export function StoreLayout() {
         </div>
       </section>
 
-      <section id="store-services" className="bg-card/40 py-14">
+      <section id="store-collections" className="bg-card/40 py-14">
         <div className="container mx-auto px-4 md:px-6">
           <div className="mx-auto max-w-3xl text-center">
-            <h2 className="font-headline text-3xl font-bold md:text-4xl">In-Store Services & Departments</h2>
+            <h2 className="font-headline text-3xl font-bold md:text-4xl">Curated Ways to Shop</h2>
             <p className="mt-3 text-base text-muted-foreground">
-              Everything you can access when you walk through our doors — from retail counters to wholesale support and corporate servicing.
+              Pick a ready-to-go collection tailored to the moment and we&apos;ll line up the perfect mix of products for your cart.
             </p>
           </div>
           <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
-            {services.map(service => (
-              <Card key={service.title} className="h-full border-none bg-background/90 shadow-sm">
-                <CardHeader className="flex flex-col items-start gap-3">
-                  <div className="rounded-full bg-primary/10 p-3 text-primary">
-                    <service.icon className="h-6 w-6" />
-                  </div>
-                  <CardTitle className="text-lg font-semibold">{service.title}</CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0 text-sm text-muted-foreground">{service.description}</CardContent>
-              </Card>
-            ))}
+            {shoppingCollections.map(collection => {
+              const Icon = categoryIcons[collection.category];
+              return (
+                <Card key={collection.title} className="flex h-full flex-col border-none bg-background/90 shadow-sm">
+                  <CardHeader className="flex flex-col items-start gap-3">
+                    <div className="rounded-full bg-primary/10 p-3 text-primary">
+                      {Icon && <Icon className="h-6 w-6" />}
+                    </div>
+                    <CardTitle className="text-lg font-semibold">{collection.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex flex-1 flex-col justify-between gap-4 pt-0 text-sm text-muted-foreground">
+                    <div className="space-y-3">
+                      <p>{collection.description}</p>
+                      <div className="flex flex-wrap gap-2">
+                        {collection.highlights.map(highlight => (
+                          <Badge key={highlight} variant="secondary" className="rounded-full">
+                            {highlight}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                    <Button
+                      onClick={() => handleCategorySelect(collection.category)}
+                      className="w-fit gap-2"
+                    >
+                      {collection.cta}
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  </CardContent>
+                </Card>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/src/components/pages/store/valliey-assistant.tsx
+++ b/src/components/pages/store/valliey-assistant.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
   MessageCircle,
   Send,
@@ -59,12 +60,24 @@ const escalationLinks = {
 };
 
 export function VallieyAssistant() {
+  const pathname = usePathname();
+  const isStoreExperience = pathname?.startsWith("/store") ?? false;
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
   const [draft, setDraft] = useState("");
   const [isThinking, setIsThinking] = useState(false);
   const endOfMessagesRef = useRef<HTMLDivElement | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const buttonPlacementClasses = isStoreExperience
+    ? "bottom-4 right-24 sm:right-28 md:bottom-6 md:right-36"
+    : "bottom-4 right-4 md:bottom-6 md:right-24";
+
+  const panelPlacementClasses = isStoreExperience
+    ? "bottom-24 right-4 sm:right-28 md:bottom-28 md:right-36"
+    : "bottom-24 right-4 md:bottom-28 md:right-24";
+
+  const continueShoppingHref = isStoreExperience ? "#store-products" : "/store#store-products";
 
   const highlightedSuggestion = useMemo(() => {
     const assistantMessages = messages.filter(message => message.author === "assistant");
@@ -132,7 +145,8 @@ export function VallieyAssistant() {
       <Button
         size="lg"
         className={cn(
-          "group fixed bottom-4 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-300 hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 md:bottom-6 md:right-24",
+          "group fixed z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-300 hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2",
+          buttonPlacementClasses,
           isOpen ? "pointer-events-none scale-90 opacity-0" : "opacity-100"
         )}
         onClick={() => setIsOpen(true)}
@@ -143,7 +157,8 @@ export function VallieyAssistant() {
 
       <div
         className={cn(
-          "fixed bottom-24 right-4 z-40 w-[min(360px,calc(100vw-2rem))] max-w-sm transition-all duration-300 ease-out md:bottom-28 md:right-24",
+          "fixed z-40 w-[min(360px,calc(100vw-2rem))] max-w-sm transition-all duration-300 ease-out",
+          panelPlacementClasses,
           isOpen
             ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
             : "pointer-events-none translate-y-6 scale-95 opacity-0"
@@ -275,7 +290,7 @@ export function VallieyAssistant() {
                   </a>
                 </Button>
                 <Button asChild variant="secondary" className="sm:col-span-2">
-                  <a href="#store-products" className="flex items-center gap-2">
+                  <a href={continueShoppingHref} className="flex items-center gap-2">
                     <ShoppingCart className="h-4 w-4" />
                     Continue shopping
                   </a>

--- a/src/components/pages/store/valliey-assistant.tsx
+++ b/src/components/pages/store/valliey-assistant.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  MessageCircle,
+  Send,
+  Sparkles,
+  X,
+  PhoneCall,
+  Mail,
+  Store,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+interface ChatMessage {
+  id: string;
+  author: "assistant" | "user";
+  content: string;
+}
+
+const initialMessages: ChatMessage[] = [
+  {
+    id: "welcome",
+    author: "assistant",
+    content:
+      "Hi there! I'm Valliey, your on-site assistant. Ask me about products, services, collections, or anything else while you shop.",
+  },
+  {
+    id: "escalate",
+    author: "assistant",
+    content:
+      "Need a person right away? Use the quick actions below to escalate any order or query to our WhatsApp or email helplines.",
+  },
+];
+
+const quickPrompts = [
+  {
+    label: "What's on special today?",
+    prompt: "What specials are running in store today?",
+  },
+  {
+    label: "Show in-store services",
+    prompt: "What services can I access in store?",
+  },
+  {
+    label: "Wholesale help",
+    prompt: "Can someone help me with a wholesale order?",
+  },
+];
+
+const escalationLinks = {
+  whatsapp: "https://wa.me/263788679000?text=Hi%20Valliey%2C%20I%20need%20help%20with%20an%20order.",
+  email: "mailto:support@valleyfarmsecrets.com?subject=Assistance%20needed%20from%20Valliey",
+};
+
+export function VallieyAssistant() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  const [draft, setDraft] = useState("");
+  const [isThinking, setIsThinking] = useState(false);
+  const endOfMessagesRef = useRef<HTMLDivElement | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const highlightedSuggestion = useMemo(() => {
+    const assistantMessages = messages.filter(message => message.author === "assistant");
+    const index = assistantMessages.length % quickPrompts.length;
+    return quickPrompts[index];
+  }, [messages]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    endOfMessagesRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages, isOpen]);
+
+  const handleSend = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedDraft = draft.trim();
+
+    if (!trimmedDraft) {
+      return;
+    }
+
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      author: "user",
+      content: trimmedDraft,
+    };
+
+    setMessages(prev => [...prev, userMessage]);
+    setDraft("");
+    setIsThinking(true);
+
+    timeoutRef.current = setTimeout(() => {
+      const assistantMessage: ChatMessage = {
+        id: `assistant-${Date.now()}`,
+        author: "assistant",
+        content: `I've taken note of \"${trimmedDraft}\". I can point you to the right department, pull this week's deals, or help you reserve items for collection. Use the quick actions if you'd like to escalate straight to the team.`,
+      };
+
+      setMessages(prev => [...prev, assistantMessage]);
+      setIsThinking(false);
+    }, 500);
+  };
+
+  const handlePromptSelect = (prompt: string) => {
+    setDraft(prompt);
+  };
+
+  const handleResetConversation = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setMessages(initialMessages);
+    setDraft("");
+    setIsThinking(false);
+  };
+
+  return (
+    <>
+      <Button
+        size="lg"
+        className={cn(
+          "group fixed bottom-4 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-300 hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 md:bottom-6 md:right-6",
+          isOpen ? "pointer-events-none scale-90 opacity-0" : "opacity-100"
+        )}
+        onClick={() => setIsOpen(true)}
+        aria-label="Open Valliey assistant"
+      >
+        <Sparkles className="h-6 w-6 transition-transform duration-300 group-hover:rotate-12" />
+      </Button>
+
+      <div
+        className={cn(
+          "fixed bottom-24 right-4 z-40 w-[min(360px,calc(100vw-2rem))] max-w-sm transition-all duration-300 ease-out md:bottom-28 md:right-6",
+          isOpen
+            ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
+            : "pointer-events-none translate-y-6 scale-95 opacity-0"
+        )}
+        aria-live="polite"
+      >
+        <Card className="overflow-hidden border border-primary/20 bg-background/95 shadow-2xl backdrop-blur">
+          <CardHeader className="flex flex-row items-start justify-between gap-3 border-b bg-gradient-to-r from-primary/15 via-background to-background/90 pb-4">
+            <div className="space-y-1">
+              <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                  <MessageCircle className="h-4 w-4" />
+                </span>
+                Valliey
+              </CardTitle>
+              <p className="text-xs text-muted-foreground">
+                Always-on support for everything happening in store. Let me know what you need!
+              </p>
+            </div>
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={handleResetConversation}
+                aria-label="Reset conversation"
+              >
+                <Sparkles className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setIsOpen(false)}
+                aria-label="Close Valliey assistant"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardHeader>
+
+          <CardContent className="space-y-4 p-4">
+            <ScrollArea className="h-64 rounded-lg border border-border/60 bg-muted/10 p-3">
+              <div className="space-y-3 text-sm">
+                {messages.map(message => (
+                  <div
+                    key={message.id}
+                    className={cn(
+                      "max-w-[85%] rounded-2xl px-4 py-3 shadow-sm",
+                      message.author === "assistant"
+                        ? "bg-primary/10 text-foreground"
+                        : "ml-auto bg-primary text-primary-foreground"
+                    )}
+                  >
+                    {message.content.split("\n").map((segment, index) => (
+                      <p key={`${message.id}-${index}`} className="leading-relaxed">
+                        {segment}
+                      </p>
+                    ))}
+                  </div>
+                ))}
+                {isThinking ? (
+                  <div className="flex max-w-[85%] items-center gap-2 rounded-2xl bg-primary/10 px-4 py-3 text-xs text-muted-foreground">
+                    <div className="flex h-2 w-8 items-center justify-between">
+                      <span className="h-2 w-2 animate-bounce rounded-full bg-primary" />
+                      <span className="h-2 w-2 animate-bounce rounded-full bg-primary [animation-delay:150ms]" />
+                      <span className="h-2 w-2 animate-bounce rounded-full bg-primary [animation-delay:300ms]" />
+                    </div>
+                    Valliey is preparing ideas…
+                  </div>
+                ) : null}
+                <div ref={endOfMessagesRef} />
+              </div>
+            </ScrollArea>
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Quick prompts</p>
+              <div className="flex flex-wrap gap-2">
+                {quickPrompts.map(item => (
+                  <Button
+                    key={item.label}
+                    variant={item.label === highlightedSuggestion.label ? "default" : "secondary"}
+                    size="sm"
+                    className="rounded-full"
+                    onClick={() => handlePromptSelect(item.prompt)}
+                  >
+                    {item.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <form onSubmit={handleSend} className="space-y-3">
+              <Textarea
+                value={draft}
+                onChange={event => setDraft(event.target.value)}
+                placeholder="Tell Valliey how she can help while you're onsite…"
+                rows={3}
+              />
+              <div className="flex items-center justify-between">
+                <Button type="submit" disabled={!draft.trim()}>
+                  Send
+                  <Send className="ml-2 h-4 w-4" />
+                </Button>
+                <Button variant="ghost" type="button" onClick={() => setIsOpen(false)}>
+                  Minimise
+                </Button>
+              </div>
+            </form>
+
+            <div className="space-y-2 border-t pt-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Escalate instantly</p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button asChild variant="outline">
+                  <a
+                    href={escalationLinks.whatsapp}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2"
+                  >
+                    <PhoneCall className="h-4 w-4" />
+                    WhatsApp helpline
+                  </a>
+                </Button>
+                <Button asChild variant="outline">
+                  <a href={escalationLinks.email} className="flex items-center gap-2">
+                    <Mail className="h-4 w-4" />
+                    Email support
+                  </a>
+                </Button>
+                <Button asChild variant="secondary" className="sm:col-span-2">
+                  <a href="#store-services" className="flex items-center gap-2">
+                    <Store className="h-4 w-4" />
+                    Explore in-store services
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/src/components/pages/store/valliey-assistant.tsx
+++ b/src/components/pages/store/valliey-assistant.tsx
@@ -8,7 +8,7 @@ import {
   X,
   PhoneCall,
   Mail,
-  Store,
+  ShoppingCart,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -28,28 +28,28 @@ const initialMessages: ChatMessage[] = [
     id: "welcome",
     author: "assistant",
     content:
-      "Hi there! I'm Valliey, your on-site assistant. Ask me about products, services, collections, or anything else while you shop.",
+      "Hi there! I'm Valliey, your shopping assistant. I can surface products, line up specials, and guide you through checkout.",
   },
   {
     id: "escalate",
     author: "assistant",
     content:
-      "Need a person right away? Use the quick actions below to escalate any order or query to our WhatsApp or email helplines.",
+      "Need a person right away? Use the quick actions below to escalate any order or payment query to our WhatsApp or email helplines.",
   },
 ];
 
 const quickPrompts = [
   {
-    label: "What's on special today?",
-    prompt: "What specials are running in store today?",
+    label: "Show flash deals",
+    prompt: "Which flash deals are available to shop right now?",
   },
   {
-    label: "Show in-store services",
-    prompt: "What services can I access in store?",
+    label: "Build my basket",
+    prompt: "Can you help me build a basket for dinners this week?",
   },
   {
-    label: "Wholesale help",
-    prompt: "Can someone help me with a wholesale order?",
+    label: "Track my order",
+    prompt: "How do I track the status of my online order?",
   },
 ];
 
@@ -106,7 +106,7 @@ export function VallieyAssistant() {
       const assistantMessage: ChatMessage = {
         id: `assistant-${Date.now()}`,
         author: "assistant",
-        content: `I've taken note of \"${trimmedDraft}\". I can point you to the right department, pull this week's deals, or help you reserve items for collection. Use the quick actions if you'd like to escalate straight to the team.`,
+        content: `I've taken note of \"${trimmedDraft}\". I can point you to the right aisle, spotlight best-sellers, or fast-track you to checkout. Use the quick actions if you'd like to escalate straight to the team.`,
       };
 
       setMessages(prev => [...prev, assistantMessage]);
@@ -132,7 +132,7 @@ export function VallieyAssistant() {
       <Button
         size="lg"
         className={cn(
-          "group fixed bottom-4 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-300 hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 md:bottom-6 md:right-6",
+          "group fixed bottom-4 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-300 hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 md:bottom-6 md:right-24",
           isOpen ? "pointer-events-none scale-90 opacity-0" : "opacity-100"
         )}
         onClick={() => setIsOpen(true)}
@@ -143,7 +143,7 @@ export function VallieyAssistant() {
 
       <div
         className={cn(
-          "fixed bottom-24 right-4 z-40 w-[min(360px,calc(100vw-2rem))] max-w-sm transition-all duration-300 ease-out md:bottom-28 md:right-6",
+          "fixed bottom-24 right-4 z-40 w-[min(360px,calc(100vw-2rem))] max-w-sm transition-all duration-300 ease-out md:bottom-28 md:right-24",
           isOpen
             ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
             : "pointer-events-none translate-y-6 scale-95 opacity-0"
@@ -160,7 +160,7 @@ export function VallieyAssistant() {
                 Valliey
               </CardTitle>
               <p className="text-xs text-muted-foreground">
-                Always-on support for everything happening in store. Let me know what you need!
+                Always-on support while you shop. Tell me what you&apos;re stocking up on and I&apos;ll guide you.
               </p>
             </div>
             <div className="flex gap-1">
@@ -240,7 +240,7 @@ export function VallieyAssistant() {
               <Textarea
                 value={draft}
                 onChange={event => setDraft(event.target.value)}
-                placeholder="Tell Valliey how she can help while you're onsite…"
+                placeholder="Tell Valliey what you're shopping for and she'll line it up…"
                 rows={3}
               />
               <div className="flex items-center justify-between">
@@ -255,7 +255,7 @@ export function VallieyAssistant() {
             </form>
 
             <div className="space-y-2 border-t pt-3">
-              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Escalate instantly</p>
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Order helplines</p>
               <div className="grid gap-2 sm:grid-cols-2">
                 <Button asChild variant="outline">
                   <a
@@ -275,9 +275,9 @@ export function VallieyAssistant() {
                   </a>
                 </Button>
                 <Button asChild variant="secondary" className="sm:col-span-2">
-                  <a href="#store-services" className="flex items-center gap-2">
-                    <Store className="h-4 w-4" />
-                    Explore in-store services
+                  <a href="#store-products" className="flex items-center gap-2">
+                    <ShoppingCart className="h-4 w-4" />
+                    Continue shopping
                   </a>
                 </Button>
               </div>

--- a/src/lib/nav-links.ts
+++ b/src/lib/nav-links.ts
@@ -10,11 +10,13 @@ import {
   Sprout,
 } from "lucide-react";
 
+export type NavLinkTone = "primary" | "accent" | "muted";
+
 export type NavLink = {
   href: string;
   label: string;
   icon: LucideIcon;
-  colorClass: string;
+  tone: NavLinkTone;
 };
 
 export const navLinks: NavLink[] = [
@@ -22,48 +24,48 @@ export const navLinks: NavLink[] = [
     href: "/producers",
     label: "For Producers",
     icon: Sprout,
-    colorClass: "text-emerald-500",
+    tone: "primary",
   },
   {
     href: "/become-a-partner",
     label: "Partner With Us",
     icon: Handshake,
-    colorClass: "text-sky-500",
+    tone: "accent",
   },
   {
     href: "/#services",
     label: "Services",
     icon: Cog,
-    colorClass: "text-purple-500",
+    tone: "primary",
   },
   {
     href: "/#locations",
     label: "Branches",
     icon: MapPin,
-    colorClass: "text-rose-500",
+    tone: "accent",
   },
   {
     href: "/#gallery",
     label: "Gallery",
     icon: Images,
-    colorClass: "text-amber-500",
+    tone: "muted",
   },
   {
     href: "/#wholesale",
     label: "Wholesale",
     icon: Boxes,
-    colorClass: "text-lime-500",
+    tone: "primary",
   },
   {
     href: "/#contact",
     label: "Contact Us",
     icon: PhoneCall,
-    colorClass: "text-orange-500",
+    tone: "accent",
   },
   {
     href: "/store",
     label: "Online Store",
     icon: ShoppingCart,
-    colorClass: "text-blue-500",
+    tone: "primary",
   },
 ];


### PR DESCRIPTION
## Summary
- overhaul the store page with an AliExpress-inspired hero that features a category rail, immersive carousel, and quick action panels
- introduce a dedicated flash deals carousel plus highlight cards that surface featured departments and weekly promotions
- showcase every in-store service in a branded grid and streamline the product browsing section with smooth category shortcuts
- add the Valliey floating assistant so shoppers get onsite guidance and can escalate to WhatsApp or email helplines instantly

## Testing
- npm run typecheck
- npm run lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cfce80b3148320ade2ea63a606ce87