### PR TITLE
Align global fonts with Google Fonts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,12 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer base {
   :root {
+    --font-body: "Poppins", sans-serif;
+    --font-headline: "Alegreya", serif;
     --background: 40 33% 98%;
     --foreground: 20 14% 4%;
     --card: 60 56% 91%;
@@ -58,6 +56,7 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-body);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the hard-coded Arial body font stack from the global stylesheet
- define CSS variables for the Poppins body text and Alegreya headline fonts already loaded by the app
- apply the body font variable in the base layer and spot-check headline components to keep using the headline font utility

## Testing
- npm run lint *(fails: command prompts for ESLint configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d0eb2eb7508320a4bfe0fa68d089d3