### PR TITLE
Add submitting state feedback to partner forms

### DIFF
--- a/src/app/become-a-partner/page.tsx
+++ b/src/app/become-a-partner/page.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
-import { Handshake, Sprout, Users, Heart, Globe, Building, User, Phone, Mail, FileText, CheckCircle } from "lucide-react";
+import { Handshake, Sprout, Users, Heart, Globe, Building, User, Phone, Mail, FileText, CheckCircle, Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -82,6 +82,7 @@ export default function BecomeAPartnerPage() {
       message: "",
     },
   });
+  const { isSubmitting } = form.formState;
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
@@ -91,19 +92,15 @@ export default function BecomeAPartnerPage() {
         body: JSON.stringify(values),
       });
 
-      if (response.ok) {
-        toast({
-          title: "✅ Thank you for submitting your partnership proposal to Valley Farm Secrets.",
-          description: "Our team will review it and get back to you within 5–7 working days. For urgent queries: +263 788 679 000 | +263 711 406 919.",
-        });
-        form.reset();
-      } else {
-        toast({
-          title: "Submission failed",
-          description: "Please try again later.",
-          variant: "destructive",
-        });
+      if (!response.ok) {
+        throw new Error("Failed to submit partnership proposal");
       }
+
+      toast({
+        title: "✅ Thank you for submitting your partnership proposal to Valley Farm Secrets.",
+        description: "Our team will review it and get back to you within 5–7 working days. For urgent queries: +263 788 679 000 | +263 711 406 919.",
+      });
+      form.reset();
     } catch (error) {
       toast({
         title: "Submission failed",
@@ -200,7 +197,25 @@ export default function BecomeAPartnerPage() {
                       <FormField control={form.control} name="message" render={({ field }) => (
                         <FormItem><FormLabel>Proposal or Message</FormLabel><FormControl><Textarea placeholder="Tell us about your proposal or how you'd like to partner with us..." rows={6} {...field} /></FormControl><FormMessage /></FormItem>
                       )} />
-                      <Button type="submit" size="lg" className="w-full" style={{ backgroundColor: '#4CAF50' }}>Submit Proposal</Button>
+                      <Button
+                        type="submit"
+                        size="lg"
+                        className="w-full"
+                        style={{ backgroundColor: '#4CAF50' }}
+                        disabled={isSubmitting}
+                      >
+                        {isSubmitting ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Submitting...
+                          </>
+                        ) : (
+                          "Submit Proposal"
+                        )}
+                      </Button>
+                      <p aria-live="polite" className="sr-only" role="status">
+                        {isSubmitting ? "Submitting..." : ""}
+                      </p>
                     </form>
                   </Form>
                 </Card>

--- a/src/components/pages/home/wholesale.tsx
+++ b/src/components/pages/home/wholesale.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { useToast } from "@/hooks/use-toast";
-import { CheckCircle } from "lucide-react";
+import { CheckCircle, Loader2 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 
 const formSchema = z.object({
@@ -31,6 +31,7 @@ export function Wholesale() {
       message: "",
     },
   });
+  const { isSubmitting } = form.formState;
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
@@ -40,19 +41,15 @@ export function Wholesale() {
         body: JSON.stringify(values),
       });
 
-      if (response.ok) {
-        toast({
-          title: "Quote Request Sent!",
-          description: "Thank you! We will get back to you shortly.",
-        });
-        form.reset();
-      } else {
-        toast({
-          title: "Submission failed",
-          description: "Please try again later.",
-          variant: "destructive",
-        });
+      if (!response.ok) {
+        throw new Error("Failed to submit wholesale enquiry");
       }
+
+      toast({
+        title: "Quote Request Sent!",
+        description: "Thank you! We will get back to you shortly.",
+      });
+      form.reset();
     } catch (error) {
       toast({
         title: "Submission failed",
@@ -156,7 +153,23 @@ export function Wholesale() {
                     </FormItem>
                   )}
                 />
-                <Button type="submit" className="w-full bg-accent text-accent-foreground hover:bg-accent/90">Request a Wholesale Quote</Button>
+                <Button
+                  type="submit"
+                  className="w-full bg-accent text-accent-foreground hover:bg-accent/90"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Submitting...
+                    </>
+                  ) : (
+                    "Request a Wholesale Quote"
+                  )}
+                </Button>
+                <p aria-live="polite" className="sr-only" role="status">
+                  {isSubmitting ? "Submitting..." : ""}
+                </p>
               </form>
             </Form>
           </Card>

--- a/src/components/pages/producers/pre-booking-form.tsx
+++ b/src/components/pages/producers/pre-booking-form.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { format } from "date-fns";
-import { CalendarIcon, CheckCircle } from "lucide-react";
+import { CalendarIcon, CheckCircle, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -51,6 +51,7 @@ export function PreBookingForm() {
       notes: "",
     },
   });
+  const { isSubmitting } = form.formState;
 
   const transportRequired = form.watch("transportRequired");
 
@@ -62,19 +63,15 @@ export function PreBookingForm() {
         body: JSON.stringify(values),
       });
 
-      if (response.ok) {
-        toast({
-          title: "Booking Submitted!",
-          description: "Thank you for pre-booking your harvest with us. We'll be in touch.",
-        });
-        form.reset();
-      } else {
-        toast({
-          title: "Submission failed",
-          description: "Please try again later.",
-          variant: "destructive",
-        });
+      if (!response.ok) {
+        throw new Error("Failed to submit pre-booking form");
       }
+
+      toast({
+        title: "Booking Submitted!",
+        description: "Thank you for pre-booking your harvest with us. We'll be in touch.",
+      });
+      form.reset();
     } catch (error) {
       toast({
         title: "Submission failed",
@@ -150,7 +147,23 @@ export function PreBookingForm() {
               <FormItem><FormLabel>Additional Notes</FormLabel><FormControl><Textarea placeholder="Any other details we should know?" {...field} /></FormControl><FormMessage /></FormItem>
             )} />
 
-            <Button type="submit" className="w-full bg-accent text-accent-foreground hover:bg-accent/90">Submit Pre-booking</Button>
+            <Button
+              type="submit"
+              className="w-full bg-accent text-accent-foreground hover:bg-accent/90"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Submitting...
+                </>
+              ) : (
+                "Submit Pre-booking"
+              )}
+            </Button>
+            <p aria-live="polite" className="sr-only" role="status">
+              {isSubmitting ? "Submitting..." : ""}
+            </p>
           </form>
         </Form>
       </CardContent>

--- a/src/components/pages/store/checkout-dialog.tsx
+++ b/src/components/pages/store/checkout-dialog.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { useCart } from './cart-context';
 import { useToast } from '@/hooks/use-toast';
 import { Separator } from '@/components/ui/separator';
+import { Loader2 } from "lucide-react";
 
 const BIKER_DELIVERY_FEE = 5.00;
 
@@ -63,6 +64,7 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
       paymentMethod: "now",
     },
   });
+  const { isSubmitting } = form.formState;
 
   const { watch, reset } = form;
   const isDiasporaGift = watch("isDiasporaGift");
@@ -79,21 +81,17 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
         body: JSON.stringify({ ...values, items: state.items, total }),
       });
 
-      if (response.ok) {
-        toast({
-          title: "Order Placed Successfully!",
-          description: "Thank you for your purchase. You'll receive a confirmation shortly.",
-        });
-        dispatch({ type: 'CLEAR_CART' });
-        onOpenChange(false);
-        reset();
-      } else {
-        toast({
-          title: "Order failed",
-          description: "Please try again later.",
-          variant: "destructive",
-        });
+      if (!response.ok) {
+        throw new Error("Failed to submit order");
       }
+
+      toast({
+        title: "Order Placed Successfully!",
+        description: "Thank you for your purchase. You'll receive a confirmation shortly.",
+      });
+      dispatch({ type: 'CLEAR_CART' });
+      onOpenChange(false);
+      reset();
     } catch (error) {
       toast({
         title: "Order failed",
@@ -169,8 +167,25 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
             </div>
             
             <DialogFooter>
-                <Button type="submit" size="lg" className="w-full bg-accent text-accent-foreground hover:bg-accent/90">Place Order</Button>
+                <Button
+                  type="submit"
+                  size="lg"
+                  className="w-full bg-accent text-accent-foreground hover:bg-accent/90"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Submitting...
+                    </>
+                  ) : (
+                    "Place Order"
+                  )}
+                </Button>
             </DialogFooter>
+            <p aria-live="polite" className="sr-only" role="status">
+              {isSubmitting ? "Submitting..." : ""}
+            </p>
           </form>
         </Form>
       </DialogContent>


### PR DESCRIPTION
## Summary
- surface react-hook-form `isSubmitting` state in wholesale, pre-booking, partner, and checkout forms
- disable submission buttons while pending, render spinner/status messaging, and centralize error handling
- announce the submitting state with an aria-live status message for assistive technology

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ebecabc08320b47f30f6655fce5e