### PR TITLE
Add rotating hero backgrounds for home and store

### DIFF
--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -2,30 +2,46 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
-import { PlaceHolderImages } from "@/lib/placeholder-images";
+import { useImageSlideshow } from "@/hooks/use-image-slideshow";
+import { getHeroBackgroundPool } from "@/lib/hero-backgrounds";
 import { ShoppingCart, Truck } from "lucide-react";
 
 export function Hero() {
-  const heroImage = PlaceHolderImages.find(p => p.id === "hero-produce");
+  const heroBackgroundPool = useMemo(() => getHeroBackgroundPool(), []);
+  const { images: heroImages, currentIndex } = useImageSlideshow(heroBackgroundPool);
 
   return (
     <section className="relative h-[80svh] w-full overflow-hidden">
-      {heroImage ? (
-        <Image
-          src={heroImage.imageUrl}
-          alt={heroImage.description}
-          fill
-          className="object-cover"
-          priority
-          data-ai-hint={heroImage.imageHint}
-        />
-      ) : (
-        <div className="w-full h-full bg-secondary" />
-      )}
+      <div className="absolute inset-0">
+        {heroImages.length > 0 ? (
+          heroImages.map((image, index) => (
+            <div
+              key={image.id}
+              className={`absolute inset-0 transition-opacity duration-1000 ease-in-out ${
+                index === currentIndex ? "opacity-100" : "opacity-0"
+              }`}
+              aria-hidden={index !== currentIndex}
+            >
+              <Image
+                src={image.imageUrl}
+                alt={image.description}
+                fill
+                className="object-cover"
+                priority={index === currentIndex}
+                loading={index === currentIndex ? "eager" : "lazy"}
+                data-ai-hint={image.imageHint}
+              />
+            </div>
+          ))
+        ) : (
+          <div className="h-full w-full bg-secondary" />
+        )}
+      </div>
 
       <div className="absolute inset-0 bg-black/50" />
-      <div className="relative z-10 flex h-full flex-col items-center justify-center text-center text-white p-4">
+      <div className="relative z-10 flex h-full flex-col items-center justify-center p-4 text-center text-white">
         <h1 className="font-headline text-5xl font-bold md:text-7xl">
           Freshness. Quality. Convenience.
         </h1>
@@ -36,7 +52,7 @@ export function Hero() {
           <Button
             asChild
             size="lg"
-            className="bg-primary hover:bg-primary/90 text-primary-foreground transform transition-transform hover:scale-105 group"
+            className="bg-primary text-primary-foreground transform transition-transform hover:scale-105 hover:bg-primary/90 group"
           >
             <Link href="/store">
               <ShoppingCart className="h-5 w-5 transition-transform group-hover:scale-110" aria-hidden="true" />
@@ -47,7 +63,7 @@ export function Hero() {
             asChild
             size="lg"
             variant="secondary"
-            className="bg-accent hover:bg-accent/90 text-accent-foreground transform transition-transform hover:scale-105 group"
+            className="bg-accent text-accent-foreground transform transition-transform hover:scale-105 hover:bg-accent/90 group"
           >
             <Link href="#wholesale">
               <Truck className="h-5 w-5 transition-transform group-hover:translate-x-1" aria-hidden="true" />

--- a/src/components/pages/store/store-layout.tsx
+++ b/src/components/pages/store/store-layout.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/carousel";
 import ProductCard from "./product-card";
 import { PlaceHolderImages } from "@/lib/placeholder-images";
+import { useImageSlideshow } from "@/hooks/use-image-slideshow";
+import { getHeroBackgroundPool } from "@/lib/hero-backgrounds";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -65,6 +67,9 @@ export function StoreLayout() {
   const [selectedCategory, setSelectedCategory] = useState<Category | "All">("All");
   const [sortOption, setSortOption] = useState<SortOption>("name-asc");
   const productSectionRef = useRef<HTMLDivElement | null>(null);
+
+  const heroBackgroundPool = useMemo(() => getHeroBackgroundPool(), []);
+  const { images: heroBackgrounds, currentIndex: heroBackgroundIndex } = useImageSlideshow(heroBackgroundPool);
 
   const specialOffers = useMemo(() => products.filter(product => product.onSpecial), []);
 
@@ -188,9 +193,36 @@ export function StoreLayout() {
     <div className="bg-muted/10 pb-16">
       <ShoppingCart />
 
-      <section className="border-b bg-gradient-to-br from-primary/10 via-background to-background py-10 lg:py-14">
-        <div className="container mx-auto px-4 md:px-6">
-          <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)_280px] xl:grid-cols-[260px_minmax(0,1fr)_320px]">
+      <section className="relative overflow-hidden border-b bg-gradient-to-br from-primary/10 via-background to-background py-10 lg:py-14">
+        <div className="absolute inset-0">
+          {heroBackgrounds.length > 0 ? (
+            heroBackgrounds.map((image, index) => (
+              <div
+                key={image.id}
+                className={`absolute inset-0 transition-opacity duration-1000 ease-in-out ${
+                  index === heroBackgroundIndex ? "opacity-100" : "opacity-0"
+                }`}
+                aria-hidden={index !== heroBackgroundIndex}
+              >
+                <Image
+                  src={image.imageUrl}
+                  alt={image.description}
+                  fill
+                  className="object-cover"
+                  priority={index === heroBackgroundIndex}
+                  loading={index === heroBackgroundIndex ? "eager" : "lazy"}
+                  data-ai-hint={image.imageHint}
+                />
+              </div>
+            ))
+          ) : (
+            <div className="h-full w-full bg-gradient-to-br from-primary/10 via-background to-background" />
+          )}
+        </div>
+        <div className="absolute inset-0 bg-gradient-to-br from-background/95 via-background/85 to-background/70" />
+        <div className="relative z-10">
+          <div className="container mx-auto px-4 md:px-6">
+            <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)_280px] xl:grid-cols-[260px_minmax(0,1fr)_320px]">
             <aside className="hidden h-full rounded-2xl border bg-card/70 backdrop-blur lg:block">
               <div className="border-b px-6 py-5">
                 <h3 className="font-headline text-lg font-semibold">Shop by Department</h3>
@@ -330,6 +362,7 @@ export function StoreLayout() {
               ))}
             </div>
           </div>
+        </div>
         </div>
       </section>
 

--- a/src/hooks/use-image-slideshow.ts
+++ b/src/hooks/use-image-slideshow.ts
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type UseImageSlideshowOptions = {
+  maxImages?: number;
+  intervalMs?: number;
+};
+
+export function useImageSlideshow<T>(
+  pool: T[],
+  { maxImages = 8, intervalMs = 7000 }: UseImageSlideshowOptions = {},
+) {
+  const filteredPool = useMemo(() => {
+    return pool.filter((item): item is T => Boolean(item));
+  }, [pool]);
+
+  const initialImages = useMemo(() => {
+    if (filteredPool.length === 0) {
+      return [] as T[];
+    }
+
+    const limit = Math.min(maxImages, filteredPool.length);
+    return filteredPool.slice(0, limit);
+  }, [filteredPool, maxImages]);
+
+  const [images, setImages] = useState<T[]>(initialImages);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (filteredPool.length === 0) {
+      setImages([]);
+      setCurrentIndex(0);
+      return;
+    }
+
+    const limit = Math.min(maxImages, filteredPool.length);
+    const shuffled = shuffleArray(filteredPool);
+    const selection = shuffled.slice(0, limit);
+
+    setImages(selection);
+    setCurrentIndex(selection.length > 0 ? Math.floor(Math.random() * selection.length) : 0);
+  }, [filteredPool, maxImages]);
+
+  useEffect(() => {
+    if (images.length <= 1) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setCurrentIndex(previous => (previous + 1) % images.length);
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [images, intervalMs]);
+
+  return { images, currentIndex };
+}
+
+function shuffleArray<T>(source: T[]) {
+  const array = [...source];
+
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+
+  return array;
+}

--- a/src/lib/hero-backgrounds.ts
+++ b/src/lib/hero-backgrounds.ts
@@ -1,0 +1,22 @@
+import { ImagePlaceholder, PlaceHolderImages } from "./placeholder-images";
+
+const HERO_BACKGROUND_IMAGE_IDS = [
+  "hero-produce",
+  "gallery-1",
+  "gallery-2",
+  "gallery-3",
+  "gallery-4",
+  "product-apples",
+  "product-carrots",
+  "product-broccoli",
+  "product-steak",
+  "product-sausages",
+  "product-chicken",
+  "product-bread",
+  "product-spices",
+  "product-eggs",
+];
+
+export function getHeroBackgroundPool(): ImagePlaceholder[] {
+  return PlaceHolderImages.filter(image => HERO_BACKGROUND_IMAGE_IDS.includes(image.id));
+}


### PR DESCRIPTION
## Summary
- add a reusable image slideshow hook and curated hero background pool to support randomized rotations
- update the home and store hero sections to layer rotating background images with existing content overlays

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0eeecf0b08320b62c0c5d498cc4be