### PR TITLE
Fix hero background pool to match new images

### DIFF
--- a/src/lib/hero-backgrounds.ts
+++ b/src/lib/hero-backgrounds.ts
@@ -1,16 +1,7 @@
 import { ImagePlaceholder, PlaceHolderImages } from "./placeholder-images";
 
-const HERO_BACKGROUND_IMAGE_IDS = [
-  "hero-1",
-  "hero-2",
-  "hero-3",
-  "hero-4",
-  "hero-5",
-  "hero-6",
-  "hero-7",
-  "hero-8",
-];
+const HERO_IMAGE_PREFIX = "hero-";
 
 export function getHeroBackgroundPool(): ImagePlaceholder[] {
-  return PlaceHolderImages.filter(image => HERO_BACKGROUND_IMAGE_IDS.includes(image.id));
+  return PlaceHolderImages.filter(image => image.id.startsWith(HERO_IMAGE_PREFIX));
 }


### PR DESCRIPTION
## Summary
- update the hero background pool helper to select any placeholder image that uses the hero- prefix so the new assets display correctly

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d10b3ce6c883208964f0d63cc958df