### PR TITLE
Embed maps for branch locations

### DIFF
--- a/src/components/pages/home/locations.tsx
+++ b/src/components/pages/home/locations.tsx
@@ -22,12 +22,23 @@ export function Locations() {
                 <CardTitle className="font-headline text-2xl">{location.city}</CardTitle>
                 <CardDescription>{location.role}</CardDescription>
               </CardHeader>
-              <CardContent className="flex-grow">
+              <CardContent className="flex-grow space-y-4">
+                <div className="relative aspect-video overflow-hidden rounded-lg border bg-muted/40">
+                  <iframe
+                    src={location.mapEmbedUrl}
+                    className="absolute inset-0 h-full w-full"
+                    style={{ border: 0 }}
+                    loading="lazy"
+                    allowFullScreen
+                    referrerPolicy="no-referrer-when-downgrade"
+                    title={`${location.city} location map`}
+                  />
+                </div>
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <MapPin className="h-4 w-4" />
                   <span>{location.address}</span>
                 </div>
-                <div className="mt-4">
+                <div className="pt-2">
                   <h4 className="font-semibold">Services Available:</h4>
                   <div className="mt-2 flex flex-wrap gap-2">
                     {location.services.map((service, i) => (
@@ -38,8 +49,8 @@ export function Locations() {
               </CardContent>
               <div className="p-6 pt-0">
                 <Button asChild className="w-full bg-accent text-accent-foreground hover:bg-accent/90 group">
-                  <Link href={location.mapLink} target="_blank" rel="noopener noreferrer">
-                    <span>View on Google Maps</span>
+                  <Link href={location.mapLink} target="_blank" rel="noopener noreferrer" aria-label={`Open ${location.city} location on Google Maps`}>
+                    <span>View larger on Google Maps</span>
                     <ExternalLink className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden="true" />
                   </Link>
                 </Button>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -113,14 +113,16 @@ export const locations = [
     role: "Head Office & Main Store",
     address: "75 Main Street, Gweru, Zimbabwe",
     services: ["Retail", "Butchery", "Groceries", "Wholesale pick-ups"],
-    mapLink: "https://www.google.com/maps/place/Valley+Farm+Secrets+-+Gweru/@-19.4532987,29.8133877,19.5z/data=!4m14!1m7!3m6!1s0x1934949bd34326b9:0x965f9389f867d850!2s75+Main+St,+Gweru!3b1!8m2!3d-19.4539183!4d29.8181887!3m5!1s0x193495958c4efd75:0x3bb86223848bd918!8m2!3d-19.4530493!4d29.813689!16s%2Fg%2F11txsg04x6?entry=ttu&g_ep=EgoyMDI1MDkwNy4wIKXMDSoASAFQAw%3D%3D"
+    mapLink: "https://www.google.com/maps/place/Valley+Farm+Secrets+-+Gweru/@-19.4532987,29.8133877,19.5z/data=!4m14!1m7!3m6!1s0x1934949bd34326b9:0x965f9389f867d850!2s75+Main+St,+Gweru!3b1!8m2!3d-19.4539183!4d29.8181887!3m5!1s0x193495958c4efd75:0x3bb86223848bd918!8m2!3d-19.4530493!4d29.813689!16s%2Fg%2F11txsg04x6?entry=ttu&g_ep=EgoyMDI1MDkwNy4wIKXMDSoASAFQAw%3D%3D",
+    mapEmbedUrl: "https://maps.google.com/maps?q=-19.4532987,29.8133877&z=17&output=embed"
   },
   {
     city: "Harare",
     role: "Administration & Order Desk",
     address: "Harare (full retail branch in progress, admin operations active)",
     services: ["Order coordination", "Account management", "Supply arrangements"],
-    mapLink: "https://www.google.com/maps/place/Valley+Farm+Secrets/@-17.8335312,31.0504988,17z/data=!3m1!4b1!4m6!3m5!1s0x1931a55f3e0116f9:0x91393f1c21700bcb!8m2!3d-17.8335312!4d31.0504988!16s%2Fg%2F11h3m77mgn?entry=ttu&g_ep=EgoyMDI1MDkwNy4wIKXMDSoASAFQAw%3D%3D"
+    mapLink: "https://www.google.com/maps/place/Valley+Farm+Secrets/@-17.8335312,31.0504988,17z/data=!3m1!4b1!4m6!3m5!1s0x1931a55f3e0116f9:0x91393f1c21700bcb!8m2!3d-17.8335312!4d31.0504988!16s%2Fg%2F11h3m77mgn?entry=ttu&g_ep=EgoyMDI1MDkwNy4wIKXMDSoASAFQAw%3D%3D",
+    mapEmbedUrl: "https://maps.google.com/maps?q=-17.8335312,31.0504988&z=16&output=embed"
   }
 ];
 


### PR DESCRIPTION
## Summary
- show an on-page Google Maps preview for each location card so visitors can view the branch map without leaving the site
- add embed URLs to the location data and update the call-to-action text to emphasise opening a larger map in Google Maps

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d11bd395108320834678a0b3b1ca49