### PR TITLE
Fix hero overlap with navbar

### DIFF
--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -13,7 +13,7 @@ export function Hero() {
   const { images: heroImages, currentIndex } = useImageSlideshow(heroBackgroundPool);
 
   return (
-    <section className="relative h-[80svh] w-full overflow-hidden">
+    <section className="relative min-h-[80svh] w-full overflow-hidden pt-24 pb-12 md:pt-32 md:pb-16">
       <div className="absolute inset-0">
         {heroImages.length > 0 ? (
           heroImages.map((image, index) => (


### PR DESCRIPTION
## Summary
- add vertical spacing to the homepage hero so its content is no longer hidden by the sticky header
- keep the hero height flexible with a min-height so the new spacing does not clip the background imagery

## Testing
- npm run lint *(fails due to existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d12b0e4e64832094756b890dc7225e