### PR TITLE
Use logo as favicon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,8 @@ export const metadata: Metadata = {
   title: "Valley Farm Secrets",
   description: "Freshness. Quality. Convenience. Your farm-to-table partner.",
   icons: {
-    icon: "/favicon.ico",
-    shortcut: "/favicon.ico",
+    icon: [{ url: "/images/logo.png", type: "image/png" }],
+    shortcut: [{ url: "/images/logo.png", type: "image/png" }],
   },
 };
 
@@ -26,7 +26,7 @@ export default function RootLayout({
     href="https://fonts.googleapis.com/css2?family=Alegreya:wght@700&family=Poppins:wght@400;600&display=swap"
     rel="stylesheet"
   />
-  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/images/logo.png" type="image/png" />
 </head>
       <body className={cn("font-body antialiased", "min-h-screen bg-background font-sans")}>
         {children}


### PR DESCRIPTION
## Summary
- point the Next.js metadata favicon configuration to the existing logo image
- update the head link tag to deliver the logo PNG as the favicon

## Testing
- npm run lint *(fails: ESLint must be installed: npm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d1377e1ad8832090e0aff0f36d4be2