### PR TITLE
feat: expose store data via firestore-backed api

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Store API
+
+The storefront data is also available through dedicated API routes designed for the upcoming Flutter client. Refer to [docs/store-api.md](docs/store-api.md) for endpoint descriptions, Firestore setup instructions, and deployment guidance.

--- a/docs/store-api.md
+++ b/docs/store-api.md
@@ -1,0 +1,195 @@
+# Valley Farm Secrets Store API
+
+The store API exposes structured data for Flutter and other client applications. It is built on top of Next.js route handlers and can source data from Firestore (preferred) or the local static catalogue if Firestore credentials are missing. All responses include a `source` field so you can confirm whether the data came from Firestore (`"firestore"`) or the in-repo fallback (`"static"`).
+
+## Base URL
+
+When running locally the API is served from `http://localhost:9002` (because `npm run dev` uses port 9002). Once deployed to Vercel the base URL becomes `https://<your-vercel-domain>`.
+
+All endpoints documented below are relative to the `/api` prefix.
+
+## Data Model
+
+```ts
+interface StoreProduct {
+  id: string;          // Firestore document id (or stringified static id)
+  name: string;
+  price: number;
+  oldPrice?: number;
+  unit: string;
+  category: string;
+  subcategory?: string;
+  image: string;       // Image identifier used by the web app
+  onSpecial: boolean;
+  createdAt?: string;  // ISO-8601 timestamp if persisted in Firestore
+  updatedAt?: string;  // ISO-8601 timestamp if persisted in Firestore
+}
+```
+
+Categories are derived from the products collection and include counts:
+
+```ts
+interface CategorySummary {
+  name: string;
+  productCount: number;
+  onSpecialCount: number;
+  subcategories: string[];
+}
+```
+
+## Endpoints
+
+### `GET /api/store/products`
+
+List products with optional filtering and cursor-based pagination.
+
+| Query param   | Type    | Description |
+| ------------- | ------- | ----------- |
+| `category`    | string  | Filter by category name (case-sensitive in Firestore, case-insensitive in fallback mode). |
+| `subcategory` | string  | Filter by subcategory. Combine with `category` for the most efficient Firestore queries. |
+| `onSpecial`   | boolean | `true` to return only products on special, `false` for non-special items. |
+| `limit`       | number  | Maximum number of items to return (1-100). Defaults to all items when omitted. |
+| `cursor`      | string  | The `id` of the last item from the previous page. |
+
+**Response**
+
+```json
+{
+  "data": [StoreProduct, ...],
+  "pagination": {
+    "limit": 20,
+    "nextCursor": "8" // omitted when there are no more results
+  },
+  "source": "firestore"
+}
+```
+
+**Notes**
+
+- If you combine multiple filters in Firestore you may be prompted to create a composite index. Suggested indexes:
+  - `category` + `name` (ascending)
+  - `category` + `subcategory` + `name` (ascending)
+  - `onSpecial` + `name` (ascending)
+- When Firestore credentials are absent the handler falls back to the static catalogue bundled with the repository.
+
+### `GET /api/store/products/{id}`
+
+Retrieve a single product by document id. Returns HTTP 404 when the product is missing.
+
+```json
+{
+  "data": StoreProduct,
+  "source": "firestore"
+}
+```
+
+### `GET /api/store/categories`
+
+Returns aggregate information for each category.
+
+```json
+{
+  "data": [CategorySummary, ...],
+  "source": "firestore"
+}
+```
+
+### Existing form submission endpoints
+
+The following endpoints already existed and continue to use Firestore for persistence:
+
+- `POST /api/orders`
+- `POST /api/wholesale`
+- `POST /api/partners`
+- `POST /api/prebookings`
+
+They expect JSON bodies that match the respective forms rendered in the web application.
+
+## Setting up Firestore
+
+1. **Create a Firebase project** (https://console.firebase.google.com) and enable the Firestore database in *Native* mode.
+2. **Create a service account key** with the *Firebase Admin SDK* role.
+3. **Add the credentials to your environment** (local `.env.local` file and Vercel project settings):
+
+   ```bash
+   FIREBASE_PROJECT_ID=your-project-id
+   FIREBASE_CLIENT_EMAIL=firebase-adminsdk@your-project-id.iam.gserviceaccount.com
+   FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+   ```
+
+   > The private key must keep the literal `\n` newlines so it can be parsed correctly at runtime.
+
+4. **Seed the initial catalogue** (optional but recommended) so Firestore contains the same products as the web app:
+
+   ```bash
+   npx tsx scripts/seed-products.ts
+   ```
+
+   You can point to a different env file by setting `DOTENV_CONFIG_PATH=./.env.production.local` before running the script.
+
+5. **Verify Firestore security rules.** For server-side access through the Admin SDK you can keep the default locked-down rules. For any direct client access you will need to tailor the rules separately.
+
+## Local development workflow
+
+1. Populate `.env.local` with the Firebase credentials.
+2. Run the seeding script once.
+3. Start the development server: `npm run dev`.
+4. Test an endpoint, e.g.:
+
+   ```bash
+   curl 'http://localhost:9002/api/store/products?category=Fruit%20%26%20Veg&limit=5'
+   ```
+
+## Deploying to Vercel
+
+1. Push your code to the Git repository connected to Vercel.
+2. In the Vercel dashboard open your project and configure the environment variables (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`). Make sure to add them to the *Production*, *Preview*, and *Development* environments as required.
+3. Trigger a deployment (manually or by pushing to the branch Vercel monitors). Vercel automatically builds the Next.js app and exposes the API routes at `https://<your-project>/api/...`.
+4. Test the deployed endpoints, for example:
+
+   ```bash
+   curl 'https://<your-project>/api/store/products?onSpecial=true'
+   ```
+
+## Using the API from Flutter
+
+1. Add the [`http`](https://pub.dev/packages/http) package to your Flutter project.
+2. Create a data source class:
+
+   ```dart
+   import 'dart:convert';
+   import 'package:http/http.dart' as http;
+
+   class StoreApiClient {
+     StoreApiClient(this.baseUrl);
+
+     final String baseUrl;
+
+     Future<List<Map<String, dynamic>>> fetchProducts({
+       String? category,
+       bool? onSpecial,
+       int? limit,
+       String? cursor,
+     }) async {
+       final uri = Uri.parse('$baseUrl/api/store/products').replace(queryParameters: {
+         if (category != null) 'category': category,
+         if (onSpecial != null) 'onSpecial': onSpecial.toString(),
+         if (limit != null) 'limit': limit.toString(),
+         if (cursor != null) 'cursor': cursor,
+       });
+
+       final response = await http.get(uri);
+       if (response.statusCode != 200) {
+         throw Exception('Failed to load products: ${response.body}');
+       }
+
+       final payload = json.decode(response.body) as Map<String, dynamic>;
+       return List<Map<String, dynamic>>.from(payload['data'] as List<dynamic>);
+     }
+   }
+   ```
+
+3. Store the `nextCursor` from the response to implement infinite scrolling.
+4. Repeat the same pattern for `GET /api/store/products/{id}` and `GET /api/store/categories` as needed.
+
+By following these steps you can keep a single source of truth for the product catalogue, power the existing Next.js storefront, and enable external clients (like your Flutter app) to consume the same data over a well-defined API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "genkit-cli": "^1.19.2",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.19.2",
         "typescript": "^5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "genkit-cli": "^1.19.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "tsx": "^4.19.2"
   }
 }

--- a/scripts/seed-products.ts
+++ b/scripts/seed-products.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { config } from "dotenv";
+
+import { getDb, isFirebaseConfigured } from "../src/lib/firebase-admin";
+import { products } from "../src/app/store/data";
+
+const envPath = process.env.DOTENV_CONFIG_PATH
+  ? path.resolve(process.cwd(), process.env.DOTENV_CONFIG_PATH)
+  : path.resolve(process.cwd(), ".env.local");
+
+if (fs.existsSync(envPath)) {
+  config({ path: envPath });
+} else {
+  config();
+}
+
+async function seedProducts() {
+  if (!isFirebaseConfigured()) {
+    console.error("Firebase credentials are missing. Check your environment variables.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const db = getDb();
+  const batch = db.batch();
+
+  for (const product of products) {
+    const ref = db.collection("products").doc(String(product.id));
+    const existing = await ref.get();
+    const now = new Date().toISOString();
+
+    const payload: Record<string, unknown> = {
+      id: product.id,
+      name: product.name,
+      price: product.price,
+      unit: product.unit,
+      category: product.category,
+      image: product.image,
+      onSpecial: product.onSpecial,
+      updatedAt: now,
+    };
+
+    if (product.oldPrice !== undefined) {
+      payload.oldPrice = product.oldPrice;
+    }
+
+    if (product.subcategory) {
+      payload.subcategory = product.subcategory;
+    }
+
+    const existingCreatedAt = existing.exists
+      ? (existing.data()?.createdAt as string | undefined) ?? existing.createTime?.toDate().toISOString()
+      : null;
+
+    payload.createdAt = existingCreatedAt ?? now;
+
+    batch.set(ref, payload, { merge: true });
+  }
+
+  await batch.commit();
+  console.log(`Seeded ${products.length} products to Firestore.`);
+}
+
+seedProducts().catch(error => {
+  console.error("Failed to seed products", error);
+  process.exitCode = 1;
+});

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../../store/products/[id]/route";

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,6 +1,1 @@
-import { NextResponse } from 'next/server';
-import { products } from '@/app/store/data';
-
-export async function GET() {
-  return NextResponse.json(products);
-}
+export { GET } from "../store/products/route";

--- a/src/app/api/store/categories/route.ts
+++ b/src/app/api/store/categories/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { listCategories } from "@/lib/firestore/products";
+
+export async function GET() {
+  try {
+    const result = await listCategories();
+    return NextResponse.json({ data: result.categories, source: result.source });
+  } catch (error) {
+    console.error("Failed to load categories", error);
+    return NextResponse.json({ error: "Unable to load categories" }, { status: 500 });
+  }
+}

--- a/src/app/api/store/products/[id]/route.ts
+++ b/src/app/api/store/products/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getProductById } from "@/lib/firestore/products";
+
+type RouteContext = {
+  params: { id: string };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const productId = decodeURIComponent(context.params.id);
+
+  try {
+    const result = await getProductById(productId);
+    if (!result.product) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: result.product, source: result.source });
+  } catch (error) {
+    console.error(`Failed to load product ${productId}`, error);
+    return NextResponse.json({ error: "Unable to load product" }, { status: 500 });
+  }
+}

--- a/src/app/api/store/products/route.ts
+++ b/src/app/api/store/products/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { listProducts } from "@/lib/firestore/products";
+
+const MAX_LIMIT = 100;
+
+function parseBooleanParam(value: string | null) {
+  if (value === null) return undefined;
+  if (["true", "1", "yes"].includes(value.toLowerCase())) return true;
+  if (["false", "0", "no"].includes(value.toLowerCase())) return false;
+  return null;
+}
+
+function parseLimit(value: string | null) {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(parsed)));
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const searchParams = url.searchParams;
+
+  const categoryValue = searchParams.get("category");
+  const subcategoryValue = searchParams.get("subcategory");
+  const category = categoryValue?.trim() ? categoryValue.trim() : undefined;
+  const subcategory = subcategoryValue?.trim() ? subcategoryValue.trim() : undefined;
+
+  const onSpecialParam = parseBooleanParam(searchParams.get("onSpecial"));
+  if (onSpecialParam === null) {
+    return NextResponse.json(
+      { error: "Invalid value for onSpecial. Use true or false." },
+      { status: 400 },
+    );
+  }
+
+  const limitParam = parseLimit(searchParams.get("limit"));
+  if (limitParam === null) {
+    return NextResponse.json(
+      { error: "Invalid value for limit. Provide a number." },
+      { status: 400 },
+    );
+  }
+
+  const cursor = searchParams.get("cursor") ?? undefined;
+
+  try {
+    const result = await listProducts({
+      category,
+      subcategory,
+      onSpecial: onSpecialParam,
+      limit: limitParam,
+      cursor,
+    });
+
+    return NextResponse.json({
+      data: result.items,
+      pagination: {
+        nextCursor: result.nextCursor,
+        limit: limitParam,
+      },
+      source: result.source,
+    });
+  } catch (error) {
+    console.error("Failed to load products", error);
+    return NextResponse.json(
+      { error: "Unable to load products" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -3,6 +3,14 @@ import { getFirestore } from 'firebase-admin/firestore';
 
 let db: FirebaseFirestore.Firestore | null = null;
 
+export function isFirebaseConfigured() {
+  return Boolean(
+    process.env.FIREBASE_PROJECT_ID &&
+      process.env.FIREBASE_CLIENT_EMAIL &&
+      process.env.FIREBASE_PRIVATE_KEY,
+  );
+}
+
 export function getDb() {
   if (db) return db;
 

--- a/src/lib/firestore/products.ts
+++ b/src/lib/firestore/products.ts
@@ -1,0 +1,258 @@
+import { products as staticProducts } from "@/app/store/data";
+import type { Product } from "@/app/store/data";
+import { getDb, isFirebaseConfigured } from "../firebase-admin";
+
+export type StoreProduct = {
+  id: string;
+  name: string;
+  price: number;
+  oldPrice?: number;
+  unit: string;
+  category: string;
+  subcategory?: string;
+  image: string;
+  onSpecial: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type ProductFilters = {
+  category?: string;
+  subcategory?: string;
+  onSpecial?: boolean;
+  limit?: number;
+  cursor?: string;
+};
+
+export type ListProductsResult = {
+  items: StoreProduct[];
+  nextCursor?: string;
+  source: "firestore" | "static";
+};
+
+export type CategorySummary = {
+  name: string;
+  productCount: number;
+  onSpecialCount: number;
+  subcategories: string[];
+};
+
+export type ListCategoriesResult = {
+  categories: CategorySummary[];
+  source: "firestore" | "static";
+};
+
+type FirestoreProductRecord = {
+  name: string;
+  price: number;
+  oldPrice?: number;
+  unit: string;
+  category: string;
+  subcategory?: string;
+  image: string;
+  onSpecial?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+function normaliseFirestoreProduct(
+  id: string,
+  data: FirestoreProductRecord,
+): StoreProduct {
+  return {
+    id,
+    name: data.name,
+    price: data.price,
+    oldPrice: typeof data.oldPrice === "number" ? data.oldPrice : undefined,
+    unit: data.unit,
+    category: data.category,
+    subcategory: data.subcategory,
+    image: data.image,
+    onSpecial: Boolean(data.onSpecial),
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+  };
+}
+
+function fromStaticProduct(product: Product): StoreProduct {
+  return {
+    id: String(product.id),
+    name: product.name,
+    price: product.price,
+    oldPrice: product.oldPrice,
+    unit: product.unit,
+    category: product.category,
+    subcategory: product.subcategory,
+    image: product.image,
+    onSpecial: product.onSpecial,
+  };
+}
+
+function applyLocalFilters(
+  allProducts: Product[],
+  filters: ProductFilters,
+): { items: StoreProduct[]; nextCursor?: string } {
+  let filtered = [...allProducts];
+
+  if (filters.category) {
+    filtered = filtered.filter(
+      product => product.category.toLowerCase() === filters.category!.toLowerCase(),
+    );
+  }
+
+  if (filters.subcategory) {
+    filtered = filtered.filter(product =>
+      product.subcategory?.toLowerCase() === filters.subcategory!.toLowerCase(),
+    );
+  }
+
+  if (typeof filters.onSpecial === "boolean") {
+    filtered = filtered.filter(product => product.onSpecial === filters.onSpecial);
+  }
+
+  filtered.sort((a, b) => a.name.localeCompare(b.name));
+
+  if (filters.cursor) {
+    const cursorIndex = filtered.findIndex(product => String(product.id) === filters.cursor);
+    if (cursorIndex >= 0) {
+      filtered = filtered.slice(cursorIndex + 1);
+    }
+  }
+
+  if (typeof filters.limit === "number") {
+    const safeLimit = Math.max(1, Math.floor(filters.limit));
+    const limited = filtered.slice(0, safeLimit);
+    const hasMore = filtered.length > safeLimit;
+
+    return {
+      items: limited.map(fromStaticProduct),
+      nextCursor: hasMore && limited.length > 0 ? String(limited[limited.length - 1].id) : undefined,
+    };
+  }
+
+  return {
+    items: filtered.map(fromStaticProduct),
+  };
+}
+
+export async function listProducts(filters: ProductFilters = {}): Promise<ListProductsResult> {
+  if (!isFirebaseConfigured()) {
+    const { items, nextCursor } = applyLocalFilters(staticProducts, filters);
+    return { items, nextCursor, source: "static" };
+  }
+
+  const db = getDb();
+  let query: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = db.collection("products");
+
+  if (filters.category) {
+    query = query.where("category", "==", filters.category);
+  }
+
+  if (filters.subcategory) {
+    query = query.where("subcategory", "==", filters.subcategory);
+  }
+
+  if (typeof filters.onSpecial === "boolean") {
+    query = query.where("onSpecial", "==", filters.onSpecial);
+  }
+
+  query = query.orderBy("name");
+
+  if (filters.cursor) {
+    const cursorDoc = await db.collection("products").doc(filters.cursor).get();
+    if (cursorDoc.exists) {
+      query = query.startAfter(cursorDoc);
+    }
+  }
+
+  const limit = typeof filters.limit === "number" ? Math.max(1, Math.floor(filters.limit)) : undefined;
+  if (limit) {
+    query = query.limit(limit);
+  }
+
+  const snapshot = await query.get();
+  const items = snapshot.docs.map(doc => normaliseFirestoreProduct(doc.id, doc.data() as FirestoreProductRecord));
+  const hasMore = Boolean(limit && snapshot.size === limit);
+  const nextCursor = hasMore && snapshot.docs.length > 0 ? snapshot.docs[snapshot.docs.length - 1].id : undefined;
+
+  return { items, nextCursor, source: "firestore" };
+}
+
+export async function getProductById(id: string): Promise<{ product: StoreProduct | null; source: "firestore" | "static" }> {
+  if (!isFirebaseConfigured()) {
+    const match = staticProducts.find(product => String(product.id) === id);
+    return {
+      product: match ? fromStaticProduct(match) : null,
+      source: "static",
+    };
+  }
+
+  const db = getDb();
+  const doc = await db.collection("products").doc(id).get();
+
+  if (!doc.exists) {
+    return { product: null, source: "firestore" };
+  }
+
+  return {
+    product: normaliseFirestoreProduct(doc.id, doc.data() as FirestoreProductRecord),
+    source: "firestore",
+  };
+}
+
+export async function listCategories(): Promise<ListCategoriesResult> {
+  if (!isFirebaseConfigured()) {
+    const summaries = new Map<string, CategorySummary>();
+
+    for (const product of staticProducts) {
+      const summary = summaries.get(product.category) ?? {
+        name: product.category,
+        productCount: 0,
+        onSpecialCount: 0,
+        subcategories: [],
+      };
+
+      summary.productCount += 1;
+      if (product.onSpecial) summary.onSpecialCount += 1;
+      if (product.subcategory && !summary.subcategories.includes(product.subcategory)) {
+        summary.subcategories.push(product.subcategory);
+      }
+
+      summaries.set(product.category, summary);
+    }
+
+    const categories = Array.from(summaries.values()).sort((a, b) => a.name.localeCompare(b.name));
+    return { categories, source: "static" };
+  }
+
+  const db = getDb();
+  const snapshot = await db
+    .collection("products")
+    .select("category", "subcategory", "onSpecial")
+    .get();
+
+  const summaries = new Map<string, CategorySummary>();
+
+  snapshot.forEach(doc => {
+    const data = doc.data() as Pick<FirestoreProductRecord, "category" | "subcategory" | "onSpecial">;
+    if (!data.category) return;
+
+    const summary = summaries.get(data.category) ?? {
+      name: data.category,
+      productCount: 0,
+      onSpecialCount: 0,
+      subcategories: [],
+    };
+
+    summary.productCount += 1;
+    if (data.onSpecial) summary.onSpecialCount += 1;
+    if (data.subcategory && !summary.subcategories.includes(data.subcategory)) {
+      summary.subcategories.push(data.subcategory);
+    }
+
+    summaries.set(data.category, summary);
+  });
+
+  const categories = Array.from(summaries.values()).sort((a, b) => a.name.localeCompare(b.name));
+  return { categories, source: "firestore" };
+}


### PR DESCRIPTION
## Summary
- add Firestore-backed product data helpers and API routes for listing, filtering, and retrieving store catalogue entries with a static fallback
- document the new API, database configuration, and deployment steps alongside a Firestore seeding utility
- update project metadata to support the seeding script and surface the API docs in the README

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d152e10ca08320aab6ba89b35d1c5f