### PR TITLE
Add store API data layer and configuration

### DIFF
--- a/e_valley_store/lib/src/store/models/category_summary.dart
+++ b/e_valley_store/lib/src/store/models/category_summary.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'category_summary.g.dart';
+
+@JsonSerializable()
+class CategorySummary {
+  const CategorySummary({
+    required this.name,
+    required this.productCount,
+    required this.onSpecialCount,
+    required this.subcategories,
+  });
+
+  final String name;
+  final int productCount;
+  final int onSpecialCount;
+  final List<String> subcategories;
+
+  factory CategorySummary.fromJson(Map<String, dynamic> json) =>
+      _$CategorySummaryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CategorySummaryToJson(this);
+}

--- a/e_valley_store/lib/src/store/models/category_summary.g.dart
+++ b/e_valley_store/lib/src/store/models/category_summary.g.dart
@@ -1,0 +1,19 @@
+part of 'category_summary.dart';
+
+CategorySummary _$CategorySummaryFromJson(Map<String, dynamic> json) =>
+    CategorySummary(
+      name: json['name'] as String,
+      productCount: json['productCount'] as int,
+      onSpecialCount: json['onSpecialCount'] as int,
+      subcategories: (json['subcategories'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+    );
+
+Map<String, dynamic> _$CategorySummaryToJson(CategorySummary instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'productCount': instance.productCount,
+      'onSpecialCount': instance.onSpecialCount,
+      'subcategories': instance.subcategories,
+    };

--- a/e_valley_store/lib/src/store/models/models.dart
+++ b/e_valley_store/lib/src/store/models/models.dart
@@ -1,0 +1,5 @@
+export 'category_summary.dart';
+export 'store_api_responses.dart';
+export 'store_api_source.dart';
+export 'store_pagination.dart';
+export 'store_product.dart';

--- a/e_valley_store/lib/src/store/models/store_api_responses.dart
+++ b/e_valley_store/lib/src/store/models/store_api_responses.dart
@@ -1,0 +1,59 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'category_summary.dart';
+import 'store_api_source.dart';
+import 'store_pagination.dart';
+import 'store_product.dart';
+
+part 'store_api_responses.g.dart';
+
+@JsonSerializable()
+class StoreProductsResponse {
+  const StoreProductsResponse({
+    required this.data,
+    this.pagination,
+    required this.source,
+  });
+
+  final List<StoreProduct> data;
+  final StorePagination? pagination;
+  final StoreApiSource source;
+
+  factory StoreProductsResponse.fromJson(Map<String, dynamic> json) =>
+      _$StoreProductsResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StoreProductsResponseToJson(this);
+}
+
+@JsonSerializable()
+class StoreProductResponse {
+  const StoreProductResponse({
+    required this.data,
+    required this.source,
+  });
+
+  final StoreProduct data;
+  final StoreApiSource source;
+
+  factory StoreProductResponse.fromJson(Map<String, dynamic> json) =>
+      _$StoreProductResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StoreProductResponseToJson(this);
+}
+
+@JsonSerializable()
+class CategorySummariesResponse {
+  const CategorySummariesResponse({
+    required this.data,
+    required this.source,
+  });
+
+  final List<CategorySummary> data;
+  final StoreApiSource source;
+
+  factory CategorySummariesResponse.fromJson(Map<String, dynamic> json) =>
+      _$CategorySummariesResponseFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$CategorySummariesResponseToJson(this);
+}

--- a/e_valley_store/lib/src/store/models/store_api_responses.g.dart
+++ b/e_valley_store/lib/src/store/models/store_api_responses.g.dart
@@ -1,0 +1,74 @@
+part of 'store_api_responses.dart';
+
+StoreProductsResponse _$StoreProductsResponseFromJson(
+        Map<String, dynamic> json) =>
+    StoreProductsResponse(
+      data: (json['data'] as List<dynamic>)
+          .map((e) => StoreProduct.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      pagination: json['pagination'] == null
+          ? null
+          : StorePagination.fromJson(
+              json['pagination'] as Map<String, dynamic>,
+            ),
+      source: _storeApiSourceFromJson(json['source']),
+    );
+
+Map<String, dynamic> _$StoreProductsResponseToJson(
+        StoreProductsResponse instance) =>
+    <String, dynamic>{
+      'data': instance.data.map((e) => e.toJson()).toList(),
+      'pagination': instance.pagination?.toJson(),
+      'source': _storeApiSourceToJson(instance.source),
+    };
+
+StoreProductResponse _$StoreProductResponseFromJson(
+        Map<String, dynamic> json) =>
+    StoreProductResponse(
+      data: StoreProduct.fromJson(json['data'] as Map<String, dynamic>),
+      source: _storeApiSourceFromJson(json['source']),
+    );
+
+Map<String, dynamic> _$StoreProductResponseToJson(
+        StoreProductResponse instance) =>
+    <String, dynamic>{
+      'data': instance.data.toJson(),
+      'source': _storeApiSourceToJson(instance.source),
+    };
+
+CategorySummariesResponse _$CategorySummariesResponseFromJson(
+        Map<String, dynamic> json) =>
+    CategorySummariesResponse(
+      data: (json['data'] as List<dynamic>)
+          .map((e) => CategorySummary.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      source: _storeApiSourceFromJson(json['source']),
+    );
+
+Map<String, dynamic> _$CategorySummariesResponseToJson(
+        CategorySummariesResponse instance) =>
+    <String, dynamic>{
+      'data': instance.data.map((e) => e.toJson()).toList(),
+      'source': _storeApiSourceToJson(instance.source),
+    };
+
+StoreApiSource _storeApiSourceFromJson(Object? value) {
+  if (value is String) {
+    switch (value) {
+      case 'firestore':
+        return StoreApiSource.firestore;
+      case 'static':
+        return StoreApiSource.staticCatalog;
+    }
+  }
+  throw ArgumentError('Unknown StoreApiSource value: \$value');
+}
+
+String _storeApiSourceToJson(StoreApiSource source) {
+  switch (source) {
+    case StoreApiSource.firestore:
+      return 'firestore';
+    case StoreApiSource.staticCatalog:
+      return 'static';
+  }
+}

--- a/e_valley_store/lib/src/store/models/store_api_source.dart
+++ b/e_valley_store/lib/src/store/models/store_api_source.dart
@@ -1,0 +1,9 @@
+import 'package:json_annotation/json_annotation.dart';
+
+enum StoreApiSource {
+  @JsonValue('firestore')
+  firestore,
+
+  @JsonValue('static')
+  staticCatalog,
+}

--- a/e_valley_store/lib/src/store/models/store_pagination.dart
+++ b/e_valley_store/lib/src/store/models/store_pagination.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'store_pagination.g.dart';
+
+@JsonSerializable()
+class StorePagination {
+  const StorePagination({
+    this.limit,
+    this.nextCursor,
+  });
+
+  final int? limit;
+  final String? nextCursor;
+
+  factory StorePagination.fromJson(Map<String, dynamic> json) =>
+      _$StorePaginationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StorePaginationToJson(this);
+}

--- a/e_valley_store/lib/src/store/models/store_pagination.g.dart
+++ b/e_valley_store/lib/src/store/models/store_pagination.g.dart
@@ -1,0 +1,13 @@
+part of 'store_pagination.dart';
+
+StorePagination _$StorePaginationFromJson(Map<String, dynamic> json) =>
+    StorePagination(
+      limit: json['limit'] as int?,
+      nextCursor: json['nextCursor'] as String?,
+    );
+
+Map<String, dynamic> _$StorePaginationToJson(StorePagination instance) =>
+    <String, dynamic>{
+      'limit': instance.limit,
+      'nextCursor': instance.nextCursor,
+    };

--- a/e_valley_store/lib/src/store/models/store_product.dart
+++ b/e_valley_store/lib/src/store/models/store_product.dart
@@ -1,0 +1,63 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'store_product.g.dart';
+
+DateTime? _dateTimeFromIsoString(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  return DateTime.tryParse(value);
+}
+
+String? _dateTimeToIsoString(DateTime? dateTime) => dateTime?.toIso8601String();
+
+double _doubleFromJson(num value) => value.toDouble();
+
+double? _nullableDoubleFromJson(num? value) => value?.toDouble();
+
+num _doubleToJson(double value) => value;
+
+num? _nullableDoubleToJson(double? value) => value;
+
+@JsonSerializable()
+class StoreProduct {
+  const StoreProduct({
+    required this.id,
+    required this.name,
+    required this.price,
+    this.oldPrice,
+    required this.unit,
+    required this.category,
+    this.subcategory,
+    required this.image,
+    required this.onSpecial,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+
+  @JsonKey(fromJson: _doubleFromJson, toJson: _doubleToJson)
+  final double price;
+
+  @JsonKey(fromJson: _nullableDoubleFromJson, toJson: _nullableDoubleToJson)
+  final double? oldPrice;
+
+  final String unit;
+  final String category;
+  final String? subcategory;
+  final String image;
+  final bool onSpecial;
+
+  @JsonKey(fromJson: _dateTimeFromIsoString, toJson: _dateTimeToIsoString)
+  final DateTime? createdAt;
+
+  @JsonKey(fromJson: _dateTimeFromIsoString, toJson: _dateTimeToIsoString)
+  final DateTime? updatedAt;
+
+  factory StoreProduct.fromJson(Map<String, dynamic> json) =>
+      _$StoreProductFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StoreProductToJson(this);
+}

--- a/e_valley_store/lib/src/store/models/store_product.g.dart
+++ b/e_valley_store/lib/src/store/models/store_product.g.dart
@@ -1,0 +1,30 @@
+part of 'store_product.dart';
+
+StoreProduct _$StoreProductFromJson(Map<String, dynamic> json) => StoreProduct(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      price: _doubleFromJson(json['price'] as num),
+      oldPrice: _nullableDoubleFromJson(json['oldPrice'] as num?),
+      unit: json['unit'] as String,
+      category: json['category'] as String,
+      subcategory: json['subcategory'] as String?,
+      image: json['image'] as String,
+      onSpecial: json['onSpecial'] as bool,
+      createdAt: _dateTimeFromIsoString(json['createdAt'] as String?),
+      updatedAt: _dateTimeFromIsoString(json['updatedAt'] as String?),
+    );
+
+Map<String, dynamic> _$StoreProductToJson(StoreProduct instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'price': _doubleToJson(instance.price),
+      'oldPrice': _nullableDoubleToJson(instance.oldPrice),
+      'unit': instance.unit,
+      'category': instance.category,
+      'subcategory': instance.subcategory,
+      'image': instance.image,
+      'onSpecial': instance.onSpecial,
+      'createdAt': _dateTimeToIsoString(instance.createdAt),
+      'updatedAt': _dateTimeToIsoString(instance.updatedAt),
+    };

--- a/e_valley_store/lib/src/store/store.dart
+++ b/e_valley_store/lib/src/store/store.dart
@@ -1,0 +1,5 @@
+export 'models/models.dart';
+export 'store_api_client.dart';
+export 'store_api_config.dart';
+export 'store_api_exception.dart';
+export 'store_repository.dart';

--- a/e_valley_store/lib/src/store/store_api_client.dart
+++ b/e_valley_store/lib/src/store/store_api_client.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'models/models.dart';
+import 'store_api_config.dart';
+import 'store_api_exception.dart';
+
+class StoreApiClient {
+  StoreApiClient({
+    http.Client? httpClient,
+    StoreApiConfig? config,
+  })  : _httpClient = httpClient ?? http.Client(),
+        _config = config ?? const StoreApiConfig();
+
+  final http.Client _httpClient;
+  final StoreApiConfig _config;
+
+  static const _defaultHeaders = <String, String>{
+    'Accept': 'application/json',
+  };
+
+  Uri _resolve(String path, [Map<String, String?>? queryParameters]) {
+    final filtered = <String, String>{};
+    if (queryParameters != null) {
+      for (final entry in queryParameters.entries) {
+        final value = entry.value;
+        if (value != null && value.isNotEmpty) {
+          filtered[entry.key] = value;
+        }
+      }
+    }
+
+    final base = _config.baseUri;
+    final resolved = base.resolve(path);
+    return resolved.replace(queryParameters: filtered.isEmpty ? null : filtered);
+  }
+
+  Future<StoreProductsResponse> fetchProducts({
+    String? category,
+    String? subcategory,
+    bool? onSpecial,
+    int? limit,
+    String? cursor,
+  }) async {
+    final uri = _resolve('/api/store/products', {
+      'category': category,
+      'subcategory': subcategory,
+      'onSpecial': onSpecial?.toString(),
+      'limit': limit?.toString(),
+      'cursor': cursor,
+    });
+
+    final response = await _httpClient.get(uri, headers: _defaultHeaders);
+    return _decodeResponse(
+      response,
+      (json) => StoreProductsResponse.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<StoreProductResponse> fetchProductById(String id) async {
+    final uri = _resolve('/api/store/products/$id');
+    final response = await _httpClient.get(uri, headers: _defaultHeaders);
+    return _decodeResponse(
+      response,
+      (json) => StoreProductResponse.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<CategorySummariesResponse> fetchCategories() async {
+    final uri = _resolve('/api/store/categories');
+    final response = await _httpClient.get(uri, headers: _defaultHeaders);
+    return _decodeResponse(
+      response,
+      (json) =>
+          CategorySummariesResponse.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  T _decodeResponse<T>(http.Response response, T Function(Object json) parser) {
+    if (response.statusCode != 200) {
+      throw StoreApiException(
+        'Request failed with status: ${response.statusCode}. Body: ${response.body}',
+        statusCode: response.statusCode,
+      );
+    }
+
+    final payload = json.decode(response.body);
+    return parser(payload);
+  }
+
+  void close() {
+    _httpClient.close();
+  }
+}

--- a/e_valley_store/lib/src/store/store_api_config.dart
+++ b/e_valley_store/lib/src/store/store_api_config.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+
+class StoreApiConfig {
+  const StoreApiConfig({
+    this.overrideBaseUrl,
+    this.localBaseUrl = 'http://localhost:9002',
+    this.productionBaseUrl = 'https://valleyfarmsecrets.com',
+  });
+
+  final String? overrideBaseUrl;
+  final String localBaseUrl;
+  final String productionBaseUrl;
+
+  static const String _environmentBaseUrl =
+      String.fromEnvironment('STORE_API_BASE_URL');
+
+  String get baseUrl {
+    if (overrideBaseUrl != null && overrideBaseUrl!.isNotEmpty) {
+      return overrideBaseUrl!;
+    }
+
+    if (_environmentBaseUrl.isNotEmpty) {
+      return _environmentBaseUrl;
+    }
+
+    return kReleaseMode ? productionBaseUrl : localBaseUrl;
+  }
+
+  Uri get baseUri => Uri.parse(baseUrl);
+}

--- a/e_valley_store/lib/src/store/store_api_exception.dart
+++ b/e_valley_store/lib/src/store/store_api_exception.dart
@@ -1,0 +1,9 @@
+class StoreApiException implements Exception {
+  StoreApiException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'StoreApiException(statusCode: ' '\$statusCode, message: ' '\$message)';
+}

--- a/e_valley_store/lib/src/store/store_repository.dart
+++ b/e_valley_store/lib/src/store/store_repository.dart
@@ -1,0 +1,251 @@
+import 'dart:async';
+
+import 'models/models.dart';
+import 'store_api_client.dart';
+
+class StoreRepository {
+  StoreRepository(
+    this._apiClient, {
+    this.maxRetries = 3,
+    this.retryDelay = const Duration(seconds: 1),
+  });
+
+  final StoreApiClient _apiClient;
+  final int maxRetries;
+  final Duration retryDelay;
+
+  final Map<String, StoreProduct> _productCache = {};
+  final Map<_ProductQueryKey, _CachedStreamController<StoreProductsResponse>>
+      _productStreams = {};
+  final Map<String, _CachedStreamController<StoreProduct?>> _productControllers =
+      {};
+  final _CachedStreamController<CategorySummariesResponse>
+      _categoryController = _CachedStreamController<CategorySummariesResponse>();
+
+  Stream<StoreProductsResponse> watchProducts({
+    String? category,
+    String? subcategory,
+    bool? onSpecial,
+    int? limit,
+    String? cursor,
+  }) {
+    final key = _ProductQueryKey(
+      category: category,
+      subcategory: subcategory,
+      onSpecial: onSpecial,
+      limit: limit,
+      cursor: cursor,
+    );
+    final controller = _productStreams.putIfAbsent(
+      key,
+      () => _CachedStreamController<StoreProductsResponse>(),
+    );
+
+    if (controller.latest == null) {
+      unawaited(
+        refreshProducts(
+          category: category,
+          subcategory: subcategory,
+          onSpecial: onSpecial,
+          limit: limit,
+          cursor: cursor,
+        ),
+      );
+    }
+
+    return controller.stream;
+  }
+
+  Future<StoreProductsResponse> refreshProducts({
+    String? category,
+    String? subcategory,
+    bool? onSpecial,
+    int? limit,
+    String? cursor,
+  }) async {
+    final key = _ProductQueryKey(
+      category: category,
+      subcategory: subcategory,
+      onSpecial: onSpecial,
+      limit: limit,
+      cursor: cursor,
+    );
+    final controller = _productStreams.putIfAbsent(
+      key,
+      () => _CachedStreamController<StoreProductsResponse>(),
+    );
+
+    try {
+      final response = await _retry(
+        () => _apiClient.fetchProducts(
+          category: category,
+          subcategory: subcategory,
+          onSpecial: onSpecial,
+          limit: limit,
+          cursor: cursor,
+        ),
+      );
+
+      for (final product in response.data) {
+        _productCache[product.id] = product;
+        _productControllers[product.id]?.add(product);
+      }
+
+      controller.add(response);
+      return response;
+    } catch (error, stackTrace) {
+      controller.addError(error, stackTrace);
+      rethrow;
+    }
+  }
+
+  Stream<StoreProduct?> watchProduct(String id) {
+    final controller = _productControllers.putIfAbsent(
+      id,
+      () => _CachedStreamController<StoreProduct?>(),
+    );
+
+    if (controller.latest == null && _productCache.containsKey(id)) {
+      controller.add(_productCache[id]);
+    }
+
+    if (controller.latest == null) {
+      unawaited(refreshProduct(id));
+    }
+
+    return controller.stream;
+  }
+
+  Future<StoreProductResponse> refreshProduct(String id) async {
+    final controller = _productControllers.putIfAbsent(
+      id,
+      () => _CachedStreamController<StoreProduct?>(),
+    );
+
+    try {
+      final response = await _retry(() => _apiClient.fetchProductById(id));
+      final product = response.data;
+      _productCache[id] = product;
+      controller.add(product);
+      return response;
+    } catch (error, stackTrace) {
+      controller.addError(error, stackTrace);
+      rethrow;
+    }
+  }
+
+  Stream<CategorySummariesResponse> watchCategories() {
+    if (_categoryController.latest == null) {
+      unawaited(refreshCategories());
+    }
+
+    return _categoryController.stream;
+  }
+
+  Future<CategorySummariesResponse> refreshCategories() async {
+    try {
+      final response = await _retry(_apiClient.fetchCategories);
+      _categoryController.add(response);
+      return response;
+    } catch (error, stackTrace) {
+      _categoryController.addError(error, stackTrace);
+      rethrow;
+    }
+  }
+
+  Future<T> _retry<T>(Future<T> Function() action) async {
+    var attempt = 0;
+    while (true) {
+      try {
+        return await action();
+      } catch (error) {
+        attempt += 1;
+        if (attempt > maxRetries) {
+          rethrow;
+        }
+        await Future<void>.delayed(retryDelay * attempt);
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final controller in _productStreams.values) {
+      await controller.close();
+    }
+    for (final controller in _productControllers.values) {
+      await controller.close();
+    }
+    await _categoryController.close();
+    _apiClient.close();
+  }
+}
+
+class _ProductQueryKey {
+  const _ProductQueryKey({
+    this.category,
+    this.subcategory,
+    this.onSpecial,
+    this.limit,
+    this.cursor,
+  });
+
+  final String? category;
+  final String? subcategory;
+  final bool? onSpecial;
+  final int? limit;
+  final String? cursor;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _ProductQueryKey &&
+        other.category == category &&
+        other.subcategory == subcategory &&
+        other.onSpecial == onSpecial &&
+        other.limit == limit &&
+        other.cursor == cursor;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        category,
+        subcategory,
+        onSpecial,
+        limit,
+        cursor,
+      );
+}
+
+class _CachedStreamController<T> {
+  _CachedStreamController()
+      : _controller = StreamController<T>.broadcast();
+
+  final StreamController<T> _controller;
+  T? latest;
+
+  Stream<T> get stream => Stream.multi((multiController) {
+        final subscription = _controller.stream.listen(
+          multiController.add,
+          onError: multiController.addError,
+          onDone: multiController.close,
+        );
+        if (latest != null) {
+          multiController.add(latest as T);
+        }
+        multiController.onCancel = () async {
+          await subscription.cancel();
+        };
+      });
+
+  void add(T value) {
+    latest = value;
+    _controller.add(value);
+  }
+
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _controller.addError(error, stackTrace);
+  }
+
+  Future<void> close() async {
+    await _controller.close();
+  }
+}

--- a/e_valley_store/pubspec.yaml
+++ b/e_valley_store/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_fonts: 6.2.1
+  http: ^1.2.1
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   flutter_test:
@@ -46,6 +48,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.9
+  json_serializable: ^6.8.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- add HTTP and JSON serialization dependencies to the Flutter client
- implement store data models that match the documented API contracts
- build a configurable API client with a repository that caches, retries, and streams store data

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1a3d1df40832096d1e54bc585b88f