### PR TITLE
feat: expose AI flows through REST API

### DIFF
--- a/docs/store-api.md
+++ b/docs/store-api.md
@@ -105,6 +105,64 @@ The following endpoints already existed and continue to use Firestore for persis
 
 They expect JSON bodies that match the respective forms rendered in the web application.
 
+## AI helper endpoints
+
+Flutter now shares the same AI contract that powers the web experience. Both endpoints require
+`Content-Type: application/json` and, when `AI_API_TOKEN` (or `NEXT_PUBLIC_AI_API_TOKEN`) is set in
+the environment, an `Authorization: Bearer <token>` header. Each caller is limited to 10 requests per
+minute; exceeding the limit yields HTTP 429 with a `Retry-After` header.
+
+### `POST /api/ai/farming-tip`
+
+Request body:
+
+```json
+{
+  "topic": "How do I keep pests off my tomatoes?"
+}
+```
+
+Successful response:
+
+```json
+{
+  "tip": "Use a row cover to protect tomato plants and rotate crops to disrupt pest life cycles."
+}
+```
+
+Errors:
+
+| Status | Reason |
+| ------ | ------ |
+| 400 | Missing/invalid JSON body or the AI flow returned a validation error. |
+| 401 | `Authorization` header missing when a token is configured. |
+| 403 | Token present but incorrect. |
+| 415 | Incorrect `Content-Type`. |
+| 429 | Rate limit exceeded. |
+| 500 | Unexpected server failure when calling the AI flow. |
+
+### `POST /api/ai/image-caption`
+
+Request body:
+
+```json
+{
+  "imageUrl": "https://example.com/photos/strawberries.jpg"
+}
+```
+
+Successful response:
+
+```json
+{
+  "caption": "Freshly picked strawberries ready for the farmers' market."
+}
+```
+
+Errors mirror the farming-tip endpoint. In addition, the AI action enforces a 5&nbsp;MB limit and
+restricts remote images to JPEG, PNG, GIF, or WebP. When the upstream fetch rejects the content type
+or size, the handler responds with HTTP 400 and the descriptive error message from the action.
+
 ## Setting up Firestore
 
 1. **Create a Firebase project** (https://console.firebase.google.com) and enable the Firestore database in *Native* mode.

--- a/src/app/api/ai/_utils/security.ts
+++ b/src/app/api/ai/_utils/security.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const rateLimitStore = new Map<string, { count: number; reset: number }>();
+
+export interface RateLimitStatus {
+  limited: boolean;
+  remaining: number;
+  reset: number;
+  retryAfter?: number;
+}
+
+function getClientIdentifier(request: NextRequest): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const [ip] = forwardedFor.split(",");
+    if (ip) {
+      return ip.trim();
+    }
+  }
+
+  const forwardedHost =
+    request.headers.get("x-real-ip") ||
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-vercel-forwarded-for");
+  if (forwardedHost) {
+    return forwardedHost;
+  }
+
+  return "anonymous";
+}
+
+export function checkRateLimit(
+  request: NextRequest,
+  limit: number,
+  windowMs: number
+): RateLimitStatus {
+  const identifier = getClientIdentifier(request);
+  const now = Date.now();
+  const existing = rateLimitStore.get(identifier);
+
+  if (!existing || now > existing.reset) {
+    rateLimitStore.set(identifier, { count: 1, reset: now + windowMs });
+    return { limited: false, remaining: Math.max(limit - 1, 0), reset: now + windowMs };
+  }
+
+  if (existing.count >= limit) {
+    const retryAfter = Math.ceil((existing.reset - now) / 1000);
+    return { limited: true, remaining: 0, reset: existing.reset, retryAfter: Math.max(retryAfter, 1) };
+  }
+
+  existing.count += 1;
+  rateLimitStore.set(identifier, existing);
+
+  return { limited: false, remaining: Math.max(limit - existing.count, 0), reset: existing.reset };
+}
+
+export function applyRateLimitHeaders(
+  response: NextResponse,
+  limit: number,
+  status: RateLimitStatus
+) {
+  response.headers.set("X-RateLimit-Limit", String(limit));
+  response.headers.set("X-RateLimit-Remaining", String(Math.max(status.remaining, 0)));
+  response.headers.set("X-RateLimit-Reset", String(Math.floor(status.reset / 1000)));
+  if (status.retryAfter !== undefined) {
+    response.headers.set("Retry-After", String(status.retryAfter));
+  }
+}
+
+export interface AuthCheckResult {
+  authorized: boolean;
+  response?: NextResponse;
+}
+
+export function verifyAuthToken(request: NextRequest): AuthCheckResult {
+  const expectedToken = process.env.AI_API_TOKEN || process.env.NEXT_PUBLIC_AI_API_TOKEN;
+  if (!expectedToken) {
+    // Token enforcement disabled when not configured.
+    return { authorized: true };
+  }
+
+  const header = request.headers.get("authorization") || request.headers.get("x-api-key");
+  if (!header) {
+    return {
+      authorized: false,
+      response: NextResponse.json({ error: "Missing authorization token." }, { status: 401 }),
+    };
+  }
+
+  const token = header.startsWith("Bearer ") ? header.slice(7).trim() : header.trim();
+  if (token !== expectedToken) {
+    return {
+      authorized: false,
+      response: NextResponse.json({ error: "Invalid authorization token." }, { status: 403 }),
+    };
+  }
+
+  return { authorized: true };
+}

--- a/src/app/api/ai/farming-tip/route.ts
+++ b/src/app/api/ai/farming-tip/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { generateFarmingTip } from "@/app/_actions/ai";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  verifyAuthToken,
+} from "@/app/api/ai/_utils/security";
+
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10;
+
+export async function POST(request: NextRequest) {
+  const rateStatus = checkRateLimit(request, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS);
+  if (rateStatus.limited) {
+    const response = NextResponse.json(
+      { error: "Too many requests. Please wait before trying again." },
+      { status: 429 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  const authResult = verifyAuthToken(request);
+  if (!authResult.authorized) {
+    const response = authResult.response ??
+      NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  const contentType = request.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    const response = NextResponse.json(
+      { error: "Content-Type must be application/json." },
+      { status: 415 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    const response = NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  const topic = typeof body === "object" && body !== null && typeof (body as { topic?: unknown }).topic === "string"
+    ? (body as { topic: string }).topic.trim()
+    : "";
+
+  if (!topic) {
+    const response = NextResponse.json(
+      { error: "The topic field is required." },
+      { status: 400 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  try {
+    const result = await generateFarmingTip(topic);
+    if (result.error || !result.tip) {
+      const response = NextResponse.json(
+        { error: result.error ?? "Failed to generate farming tip." },
+        { status: 400 }
+      );
+      applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+      return response;
+    }
+
+    const response = NextResponse.json({ tip: result.tip });
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  } catch (error) {
+    console.error("/api/ai/farming-tip error", error);
+    const response = NextResponse.json(
+      { error: "Unexpected error while generating farming tip." },
+      { status: 500 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+}

--- a/src/app/api/ai/image-caption/route.ts
+++ b/src/app/api/ai/image-caption/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { generateImageCaption } from "@/app/_actions/ai";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  verifyAuthToken,
+} from "@/app/api/ai/_utils/security";
+
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10;
+
+export async function POST(request: NextRequest) {
+  const rateStatus = checkRateLimit(request, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS);
+  if (rateStatus.limited) {
+    const response = NextResponse.json(
+      { error: "Too many requests. Please wait before trying again." },
+      { status: 429 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  const authResult = verifyAuthToken(request);
+  if (!authResult.authorized) {
+    const response = authResult.response ??
+      NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  const contentType = request.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    const response = NextResponse.json(
+      { error: "Content-Type must be application/json." },
+      { status: 415 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    const response = NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  const imageUrl = typeof body === "object" && body !== null && typeof (body as { imageUrl?: unknown }).imageUrl === "string"
+    ? (body as { imageUrl: string }).imageUrl.trim()
+    : "";
+
+  if (!imageUrl) {
+    const response = NextResponse.json(
+      { error: "The imageUrl field is required." },
+      { status: 400 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+
+  try {
+    const result = await generateImageCaption(imageUrl);
+    if (result.error || !result.caption) {
+      const response = NextResponse.json(
+        { error: result.error ?? "Failed to generate image caption." },
+        { status: 400 }
+      );
+      applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+      return response;
+    }
+
+    const response = NextResponse.json({ caption: result.caption });
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  } catch (error) {
+    console.error("/api/ai/image-caption error", error);
+    const response = NextResponse.json(
+      { error: "Unexpected error while generating image caption." },
+      { status: 500 }
+    );
+    applyRateLimitHeaders(response, RATE_LIMIT_MAX_REQUESTS, rateStatus);
+    return response;
+  }
+}

--- a/src/components/pages/home/gallery.tsx
+++ b/src/components/pages/home/gallery.tsx
@@ -12,7 +12,7 @@ import {
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from '@/components/ui/button';
 import { PlaceHolderImages } from "@/lib/placeholder-images";
-import { generateImageCaption } from '@/app/_actions/ai';
+import { requestImageCaption } from '@/lib/ai-client';
 import { Sparkles, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
@@ -32,7 +32,7 @@ export function Gallery() {
 
   const handleGenerateCaption = async (image: GalleryImage) => {
     setLoadingStates(prev => ({ ...prev, [image.id]: true }));
-    const result = await generateImageCaption(image.imageUrl);
+    const result = await requestImageCaption(image.imageUrl);
     if (result.error) {
         toast({
             title: "Error",

--- a/src/components/pages/producers/farmers-forum.tsx
+++ b/src/components/pages/producers/farmers-forum.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Lightbulb, Loader2 } from "lucide-react";
-import { generateFarmingTip } from '@/app/_actions/ai';
+import { requestFarmingTip } from '@/lib/ai-client';
 import { useToast } from '@/hooks/use-toast';
 import { Separator } from '@/components/ui/separator';
 
@@ -30,7 +30,7 @@ export function FarmersForum() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     setTip(null);
-    const result = await generateFarmingTip(values.topic);
+    const result = await requestFarmingTip(values.topic);
     if (result.error) {
         toast({
             title: "Error",

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -1,0 +1,91 @@
+const API_TOKEN = process.env.NEXT_PUBLIC_AI_API_TOKEN;
+
+interface FarmingTipResponse {
+  tip: string;
+}
+
+interface ImageCaptionResponse {
+  caption: string;
+}
+
+interface ApiResult<T> {
+  data: T | null;
+  error: string | null;
+}
+
+async function parseJson(response: Response): Promise<unknown | null> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+async function handleResponse<T>(response: Response): Promise<ApiResult<T>> {
+  const payload = await parseJson(response);
+  if (!response.ok) {
+    const message = (() => {
+      if (payload && typeof payload === "object" && "error" in payload) {
+        const possibleMessage = (payload as { error?: unknown }).error;
+        if (typeof possibleMessage === "string") {
+          return possibleMessage;
+        }
+      }
+      return `Request failed with status ${response.status}`;
+    })();
+    return { data: null, error: message };
+  }
+
+  return { data: payload as T, error: null };
+}
+
+function buildHeaders(): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+    ...(API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {}),
+  };
+}
+
+export async function requestFarmingTip(topic: string): Promise<{ tip: string | null; error: string | null }> {
+  try {
+    const response = await fetch("/api/ai/farming-tip", {
+      method: "POST",
+      headers: buildHeaders(),
+      body: JSON.stringify({ topic }),
+    });
+
+    const result = await handleResponse<FarmingTipResponse>(response);
+    return {
+      tip: result.data?.tip ?? null,
+      error: result.error,
+    };
+  } catch (error) {
+    console.error("Failed to request farming tip", error);
+    return {
+      tip: null,
+      error: error instanceof Error ? error.message : "Failed to contact the AI service.",
+    };
+  }
+}
+
+export async function requestImageCaption(imageUrl: string): Promise<{ caption: string | null; error: string | null }> {
+  try {
+    const response = await fetch("/api/ai/image-caption", {
+      method: "POST",
+      headers: buildHeaders(),
+      body: JSON.stringify({ imageUrl }),
+    });
+
+    const result = await handleResponse<ImageCaptionResponse>(response);
+    return {
+      caption: result.data?.caption ?? null,
+      error: result.error,
+    };
+  } catch (error) {
+    console.error("Failed to request image caption", error);
+    return {
+      caption: null,
+      error: error instanceof Error ? error.message : "Failed to contact the AI service.",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add REST route handlers for farming tips and image captions with rate limiting and optional token auth
- create a shared AI client for browser requests and update the farmers forum and gallery components to use the REST API
- extend the API documentation so Flutter clients can call the AI helpers with the correct headers and error handling

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1b143e8108320835eac8341312c21