### PR TITLE
Allow Dart 3.9.0 SDK

### DIFF
--- a/e_valley_store/pubspec.lock
+++ b/e_valley_store/pubspec.lock
@@ -337,5 +337,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/e_valley_store/pubspec.yaml
+++ b/e_valley_store/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.9.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
## Summary
- loosen the Dart SDK constraint in pubspec.yaml to accept version 3.9.0
- align the pubspec.lock SDK metadata with the updated constraint

## Testing
- no tests were run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1b99d1d78832090cb769b9b2e48d7