### PR TITLE
Fix store API messaging and cart filtering

### DIFF
--- a/e_valley_store/lib/src/store/models/store_api_responses.g.dart
+++ b/e_valley_store/lib/src/store/models/store_api_responses.g.dart
@@ -61,7 +61,7 @@ StoreApiSource _storeApiSourceFromJson(Object? value) {
         return StoreApiSource.staticCatalog;
     }
   }
-  throw ArgumentError('Unknown StoreApiSource value: \$value');
+  throw ArgumentError('Unknown StoreApiSource value: $value');
 }
 
 String _storeApiSourceToJson(StoreApiSource source) {

--- a/e_valley_store/lib/src/store/store_api_exception.dart
+++ b/e_valley_store/lib/src/store/store_api_exception.dart
@@ -5,5 +5,6 @@ class StoreApiException implements Exception {
   final int? statusCode;
 
   @override
-  String toString() => 'StoreApiException(statusCode: ' '\$statusCode, message: ' '\$message)';
+  String toString() =>
+      'StoreApiException(statusCode: $statusCode, message: $message)';
 }

--- a/e_valley_store/lib/src/store/view/store_screen.dart
+++ b/e_valley_store/lib/src/store/view/store_screen.dart
@@ -117,7 +117,7 @@ class _StoreScreenState extends State<StoreScreen> {
       _showSpecialsOnly || _selectedCategory != null || _searchTerm.isNotEmpty;
 
   List<StoreProduct> _applyFilters(List<StoreProduct> products) {
-    var filtered = products;
+    var filtered = List<StoreProduct>.from(products);
 
     if (_showSpecialsOnly) {
       filtered = filtered.where((product) => product.onSpecial).toList();


### PR DESCRIPTION
## Summary
- avoid mutating the original product list when applying client-side store filters by working on a copy
- ensure StoreApiException and generated StoreApiSource parsing surface real values in their error messages

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d50a0df48320834852049e995273