### PR TITLE
Update branch roles for Gweru and Harare

### DIFF
--- a/src/components/valley-ai-assistant.tsx
+++ b/src/components/valley-ai-assistant.tsx
@@ -469,7 +469,7 @@ const buildLocationsOverview = () => {
   return [
     "You can find us at:",
     locationDetails,
-    "Harare currently hosts our administration and order desk while the full retail branch is in progress—share your Harare needs and we’ll coordinate pickup or delivery for you.",
+    "Harare hosts our head office, main store, and order desk—share your Harare needs and we’ll coordinate pickup or delivery for you.",
   ].join("\n\n");
 };
 
@@ -479,7 +479,7 @@ const buildLocationsFollowUp = () =>
     formatBulletedList([
       "Open the Google Maps links in the Locations section of our site for step-by-step directions.",
       "For large wholesale pickups, call ahead so we can stage your order in cold storage.",
-      "Our Harare order desk can consolidate loads or schedule courier dispatches while the retail branch is finalised.",
+      "Our Harare head office order desk can consolidate loads or schedule courier dispatches for regional and out-of-town routes.",
     ]),
   ].join("\n\n");
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -110,7 +110,7 @@ export const whyChooseUsFeatures = [
 export const locations = [
   {
     city: "Gweru",
-    role: "Head Office & Main Store",
+    role: "Regional Office, Main Store & Order Desk",
     address: "75 Main Street, Gweru, Zimbabwe",
     services: ["Retail", "Butchery", "Groceries", "Wholesale pick-ups"],
     mapLink: "https://www.google.com/maps/place/Valley+Farm+Secrets+-+Gweru/@-19.4532987,29.8133877,19.5z/data=!4m14!1m7!3m6!1s0x1934949bd34326b9:0x965f9389f867d850!2s75+Main+St,+Gweru!3b1!8m2!3d-19.4539183!4d29.8181887!3m5!1s0x193495958c4efd75:0x3bb86223848bd918!8m2!3d-19.4530493!4d29.813689!16s%2Fg%2F11txsg04x6?entry=ttu&g_ep=EgoyMDI1MDkwNy4wIKXMDSoASAFQAw%3D%3D",
@@ -118,8 +118,8 @@ export const locations = [
   },
   {
     city: "Harare",
-    role: "Administration & Order Desk",
-    address: "Harare (full retail branch in progress, admin operations active)",
+    role: "Head Office, Main Store & Order Desk",
+    address: "Harare (head office campus with main store and order desk)",
     services: ["Order coordination", "Account management", "Supply arrangements"],
     mapLink: "https://www.google.com/maps/place/Valley+Farm+Secrets/@-17.8335312,31.0504988,17z/data=!3m1!4b1!4m6!3m5!1s0x1931a55f3e0116f9:0x91393f1c21700bcb!8m2!3d-17.8335312!4d31.0504988!16s%2Fg%2F11h3m77mgn?entry=ttu&g_ep=EgoyMDI1MDkwNy4wIKXMDSoASAFQAw%3D%3D",
     mapEmbedUrl: "https://maps.google.com/maps?q=-17.8335312,31.0504988&z=16&output=embed"


### PR DESCRIPTION
## Summary
- update the Gweru location label to "Regional Office, Main Store & Order Desk"
- update the Harare location label and address blurb to reflect the head office, main store, and order desk
- refresh AI assistant copy so Harare messaging matches the new branch designations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2db6d026c832099c3ff4264d53c06