### PR TITLE
Align Flutter WebView tests with shell behavior

### DIFF
--- a/e_valley_store/pubspec.lock
+++ b/e_valley_store/pubspec.lock
@@ -233,7 +233,7 @@ packages:
     source: hosted
     version: "3.15.0"
   webview_flutter_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: webview_flutter_platform_interface
       sha256: d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d

--- a/e_valley_store/pubspec.yaml
+++ b/e_valley_store/pubspec.yaml
@@ -46,6 +46,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  webview_flutter_platform_interface: ^2.10.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/e_valley_store/test/helpers/fake_webview_platform.dart
+++ b/e_valley_store/test/helpers/fake_webview_platform.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/widgets.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+class FakeWebViewPlatform extends WebViewPlatform {
+  FakeWebViewPlatform();
+
+  FakePlatformWebViewController? lastController;
+
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+    PlatformWebViewControllerCreationParams params,
+  ) {
+    final controller = FakePlatformWebViewController(params);
+    lastController = controller;
+    return controller;
+  }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+    PlatformNavigationDelegateCreationParams params,
+  ) {
+    return FakePlatformNavigationDelegate(params);
+  }
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+    PlatformWebViewWidgetCreationParams params,
+  ) {
+    return FakePlatformWebViewWidget(params);
+  }
+}
+
+class FakePlatformWebViewController extends PlatformWebViewController {
+  FakePlatformWebViewController(super.params)
+      : super.implementation(params);
+
+  Uri? lastLoadedUri;
+  JavaScriptMode? javaScriptMode;
+  Color? backgroundColor;
+  FakePlatformNavigationDelegate? navigationDelegate;
+  bool canGoBackValue = false;
+  bool goBackCalled = false;
+  bool reloadCalled = false;
+
+  @override
+  Future<void> loadRequest(LoadRequestParams params) async {
+    lastLoadedUri = params.uri;
+  }
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) async {
+    this.javaScriptMode = javaScriptMode;
+  }
+
+  @override
+  Future<void> setBackgroundColor(Color color) async {
+    backgroundColor = color;
+  }
+
+  @override
+  Future<void> setPlatformNavigationDelegate(
+    PlatformNavigationDelegate handler,
+  ) async {
+    navigationDelegate = handler as FakePlatformNavigationDelegate;
+  }
+
+  @override
+  Future<bool> canGoBack() async => canGoBackValue;
+
+  @override
+  Future<void> goBack() async {
+    goBackCalled = true;
+  }
+
+  @override
+  Future<void> reload() async {
+    reloadCalled = true;
+  }
+}
+
+class FakePlatformNavigationDelegate extends PlatformNavigationDelegate {
+  FakePlatformNavigationDelegate(super.params)
+      : super.implementation(params);
+
+  PageEventCallback? onPageStarted;
+  PageEventCallback? onPageFinished;
+  ProgressCallback? onProgress;
+
+  @override
+  Future<void> setOnPageStarted(PageEventCallback onPageStarted) async {
+    this.onPageStarted = onPageStarted;
+  }
+
+  @override
+  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {
+    this.onPageFinished = onPageFinished;
+  }
+
+  @override
+  Future<void> setOnProgress(ProgressCallback onProgress) async {
+    this.onProgress = onProgress;
+  }
+}
+
+class FakePlatformWebViewWidget extends PlatformWebViewWidget {
+  FakePlatformWebViewWidget(super.params)
+      : super.implementation(params);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(key: Key('fake-webview'));
+  }
+}

--- a/e_valley_store/test/widget_test.dart
+++ b/e_valley_store/test/widget_test.dart
@@ -5,31 +5,72 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:e_valley_store/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'helpers/fake_webview_platform.dart';
 
 void main() {
-  testWidgets('App displays home content and navigates to Producers',
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeWebViewPlatform fakePlatform;
+
+  setUp(() {
+    fakePlatform = FakeWebViewPlatform();
+    WebViewPlatform.instance = fakePlatform;
+  });
+
+  testWidgets('renders store shell UI and loads the storefront URL',
       (WidgetTester tester) async {
     await tester.pumpWidget(const EValleyStoreApp());
+    await tester.pump();
 
-    expect(find.text('Home'), findsWidgets);
+    expect(find.text('E-Valley Store'), findsOneWidget);
+    expect(find.byIcon(Icons.refresh), findsOneWidget);
+    expect(find.byKey(const Key('fake-webview')), findsOneWidget);
+
+    final controller = fakePlatform.lastController;
+    expect(controller, isNotNull);
     expect(
-      find.textContaining('home hub will highlight featured stories'),
-      findsOneWidget,
+      controller!.lastLoadedUri,
+      Uri.parse('https://valleyfarmsecrets.com/store'),
     );
 
-    await tester.tap(find.byTooltip('Open navigation menu'));
-    await tester.pumpAndSettle();
+    final progressFinder = find.byType(LinearProgressIndicator);
+    expect(progressFinder, findsOneWidget);
+    final initialIndicator =
+        tester.widget<LinearProgressIndicator>(progressFinder);
+    expect(initialIndicator.value, isNull);
 
-    await tester.tap(find.text('Producers').last);
-    await tester.pumpAndSettle();
+    controller.navigationDelegate?.onProgress?.call(45);
+    await tester.pump();
+    final midIndicator =
+        tester.widget<LinearProgressIndicator>(progressFinder);
+    expect(midIndicator.value, closeTo(0.45, 1e-2));
 
-    expect(find.text('Producers'), findsWidgets);
-    expect(
-      find.textContaining('Resources and programs tailored for agricultural'),
-      findsOneWidget,
-    );
+    controller.navigationDelegate?.onPageFinished?.call('done');
+    await tester.pump();
+    expect(progressFinder, findsNothing);
+
+    await tester.tap(find.byIcon(Icons.refresh));
+    await tester.pump();
+    expect(controller.reloadCalled, isTrue);
+  });
+
+  testWidgets('back navigation uses the webview history when available',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const EValleyStoreApp());
+    await tester.pump();
+
+    final controller = fakePlatform.lastController!;
+    controller.canGoBackValue = true;
+
+    final willPopScope = tester.widget<WillPopScope>(find.byType(WillPopScope));
+    final shouldPop = await willPopScope.onWillPop!.call();
+
+    expect(shouldPop, isFalse);
+    expect(controller.goBackCalled, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- replace the outdated widget test with coverage for the WebView shell experience and back navigation
- introduce a fake `WebViewPlatform` test double so the WebView shell can be exercised without native plugins
- add the WebView platform interface as a dev dependency to support the new fakes

## Testing
- not run (flutter command unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2ff1eb3ac83208ce499e43d14f8e0