### PR TITLE
Fix Next.js build failure by removing stray identifier from data

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -86,7 +86,6 @@ export const services = [
     purchaseLink: "/store",
     purchaseLabel: "Explore Our Store",
     image: "/images/office-and-kitchenware.webp",
-main
   }
 ];
 


### PR DESCRIPTION
## Summary
- remove the stray `main` token from the services data so the Next.js prerenderer no longer references an undefined variable

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3bc37b0c88320913740bac3d97d95