### PR TITLE
Improve EcoCash error handling without Firebase

### DIFF
--- a/src/app/api/payments/ecocash/route.ts
+++ b/src/app/api/payments/ecocash/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { initiateEcocashPayment } from '@/lib/payments/ecocash';
+import { isFirebaseConfigured } from '@/lib/firebase-admin';
+
+export async function POST(req: Request) {
+  try {
+    if (!isFirebaseConfigured()) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'EcoCash payments are temporarily unavailable. Please try again soon.',
+        },
+        { status: 503 },
+      );
+    }
+
+    const body = await req.json();
+    const amount = Number(body?.amount);
+    const phoneNumber: string | undefined = body?.phoneNumber;
+    const currency: string = body?.currency ?? 'USD';
+    const metadata = body?.metadata;
+    const orderId: string | undefined = body?.orderId;
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return NextResponse.json(
+        { success: false, error: 'A valid payment amount is required.' },
+        { status: 400 },
+      );
+    }
+
+    if (!phoneNumber || typeof phoneNumber !== 'string' || !phoneNumber.trim()) {
+      return NextResponse.json(
+        { success: false, error: 'An EcoCash phone number is required.' },
+        { status: 400 },
+      );
+    }
+
+    const payment = await initiateEcocashPayment({
+      amount,
+      phoneNumber: phoneNumber.trim(),
+      currency,
+      metadata,
+      orderId,
+    });
+
+    return NextResponse.json({ success: true, ...payment });
+  } catch (error) {
+    console.error('Error initiating EcoCash payment:', error);
+
+    if (
+      error instanceof Error &&
+      error.message?.toLowerCase().includes('firebase environment variables are not set')
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'EcoCash payments are temporarily unavailable. Please try again soon.',
+        },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json(
+      { success: false, error: 'Failed to initiate EcoCash payment.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/pages/store/checkout-dialog.tsx
+++ b/src/components/pages/store/checkout-dialog.tsx
@@ -33,6 +33,7 @@ const formSchema = z.object({
   customerPhone: z.string().optional(),
   customerAddress: z.string().optional(),
   paymentMethod: z.enum(["now", "on_delivery"]).default("now"),
+  paymentPhone: z.string().optional(),
 }).superRefine((data, ctx) => {
     if (data.isDiasporaGift) {
         if (!data.recipientName) ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Recipient name is required.", path: ["recipientName"] });
@@ -43,6 +44,14 @@ const formSchema = z.object({
             if (!data.customerPhone) ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Your phone is required for delivery.", path: ["customerPhone"] });
             if (!data.customerAddress) ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Your address is required for delivery.", path: ["customerAddress"] });
         }
+    }
+
+    if (data.paymentMethod === 'now' && (!data.paymentPhone || !data.paymentPhone.trim())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "An EcoCash phone number is required to pay now.",
+        path: ["paymentPhone"],
+      });
     }
 });
 
@@ -69,33 +78,90 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
   const { watch, reset } = form;
   const isDiasporaGift = watch("isDiasporaGift");
   const deliveryMethod = watch("deliveryMethod");
-  
+  const paymentMethod = watch("paymentMethod");
+
   const subtotal = state.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
   const total = subtotal + (deliveryMethod === 'delivery' ? BIKER_DELIVERY_FEE : 0);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
+      let paymentReference: string | undefined;
+      let paymentMerchantCode: string | undefined;
+
+      if (values.paymentMethod === "now") {
+        const paymentResponse = await fetch("/api/payments/ecocash", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            amount: total,
+            phoneNumber: values.paymentPhone?.trim(),
+            metadata: {
+              isDiasporaGift: values.isDiasporaGift,
+              deliveryMethod: values.deliveryMethod,
+            },
+          }),
+        });
+
+        const paymentData = await paymentResponse.json().catch(() => null);
+
+        if (!paymentResponse.ok || !paymentData?.success) {
+          const message =
+            paymentData?.error ??
+            (paymentResponse.status === 503
+              ? "EcoCash payments are currently unavailable. Please try again later."
+              : "Failed to initiate EcoCash payment.");
+          throw new Error(message);
+        }
+
+        paymentReference = paymentData.reference;
+        paymentMerchantCode = paymentData.merchantCode;
+      }
+
+      const { paymentPhone, ...orderValues } = values;
+
       const response = await fetch("/api/orders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...values, items: state.items, total }),
+        body: JSON.stringify({
+          ...orderValues,
+          items: state.items,
+          total,
+          payment: {
+            method: values.paymentMethod,
+            status: values.paymentMethod === "now" ? "pending" : "pending_collection",
+            reference: paymentReference ?? null,
+            merchantCode: paymentMerchantCode ?? null,
+            phoneNumber: paymentPhone ?? null,
+          },
+        }),
       });
 
       if (!response.ok) {
         throw new Error("Failed to submit order");
       }
 
+      const referenceNote = paymentReference ? ` (Ref: ${paymentReference})` : "";
+      const merchantNote = paymentMerchantCode ?? "068951";
+
       toast({
         title: "Order Placed Successfully!",
-        description: "Thank you for your purchase. You&rsquo;ll receive a confirmation shortly.",
+        description:
+          values.paymentMethod === "now"
+            ? `An EcoCash request${referenceNote} has been raised for merchant ${merchantNote}. Please authorise the payment on your phone to confirm your order.`
+            : "Thank you for your purchase. You&rsquo;ll receive a confirmation shortly.",
       });
       dispatch({ type: 'CLEAR_CART' });
       onOpenChange(false);
       reset();
     } catch (error) {
+      console.error('Checkout submission failed', error);
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Please try again later.';
       toast({
         title: "Order failed",
-        description: "Please try again later.",
+        description: message,
         variant: "destructive",
       });
     }
@@ -155,6 +221,34 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
                     </RadioGroup><FormMessage />
                   </FormItem>
                 )} />
+              </div>
+            )}
+
+            {paymentMethod === "now" && (
+              <div className="space-y-3 rounded-md border bg-muted/40 p-4 animate-fade-in-up">
+                <div className="space-y-1">
+                  <h3 className="font-semibold">EcoCash payment</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Enter the EcoCash phone number we should bill. We&rsquo;ll raise a request against merchant
+                    <span className="font-medium"> 068951</span> once you submit the order.
+                  </p>
+                </div>
+                <FormField
+                  name="paymentPhone"
+                  control={form.control}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>EcoCash Phone Number</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g. +263 77 123 4567" {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Use the number registered with EcoCash so you can authorise the prompt immediately.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
               </div>
             )}
 

--- a/src/lib/payments/ecocash.ts
+++ b/src/lib/payments/ecocash.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'crypto';
+import { getDb, isFirebaseConfigured } from '@/lib/firebase-admin';
+
+const DEFAULT_MERCHANT_CODE = '068951';
+
+interface InitiateEcocashPaymentOptions {
+  amount: number;
+  phoneNumber: string;
+  currency?: string;
+  metadata?: Record<string, unknown>;
+  orderId?: string;
+}
+
+interface InitiateEcocashPaymentResponse {
+  reference: string;
+  merchantCode: string;
+}
+
+export async function initiateEcocashPayment({
+  amount,
+  phoneNumber,
+  currency = 'USD',
+  metadata,
+  orderId,
+}: InitiateEcocashPaymentOptions): Promise<InitiateEcocashPaymentResponse> {
+  const merchantCode = process.env.ECOCASH_MERCHANT_CODE?.trim() || DEFAULT_MERCHANT_CODE;
+
+  const reference = `ECO-${randomUUID().split('-')[0]}`.toUpperCase();
+
+  if (!isFirebaseConfigured()) {
+    throw new Error('Firebase environment variables are not set');
+  }
+
+  const db = getDb();
+
+  const paymentRecord: Record<string, unknown> = {
+    provider: 'ecocash',
+    merchantCode,
+    phoneNumber,
+    amount,
+    currency,
+    status: 'pending',
+    reference,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (metadata) {
+    paymentRecord.metadata = metadata;
+  }
+
+  if (orderId) {
+    paymentRecord.orderId = orderId;
+  }
+
+  await db.collection('payments').add(paymentRecord);
+
+  return { reference, merchantCode };
+}


### PR DESCRIPTION
## Summary
- add an EcoCash payment API route that validates input and records the request via Firestore
- persist EcoCash payment metadata using a reusable helper with a default merchant code of 068951
- extend the checkout dialog to collect the payer’s EcoCash number, trigger the payment request, and surface the reference to the shopper
- guard EcoCash payment initiation when Firebase isn’t configured and surface a friendly availability message in checkout, including defensive handling in the helper so the API consistently returns the 503 response

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df8332132083209b15734591244c64