### PR TITLE
Fix checkout dialog submission flow

### DIFF
--- a/src/components/pages/store/checkout-dialog.tsx
+++ b/src/components/pages/store/checkout-dialog.tsx
@@ -102,8 +102,12 @@ export function CheckoutDialog({ isOpen, onOpenChange }: CheckoutDialogProps) {
           }),
         });
 
-main
+        if (!paymentResponse.ok) {
+          throw new Error("Failed to initiate EcoCash payment");
         }
+
+        const paymentData: { reference?: string; merchantCode?: string } =
+          await paymentResponse.json();
 
         paymentReference = paymentData.reference;
         paymentMerchantCode = paymentData.merchantCode;
@@ -147,7 +151,10 @@ main
       reset();
     } catch (error) {
       console.error('Checkout submission failed', error);
-main
+
+      const message =
+        error instanceof Error ? error.message : 'Something went wrong while placing your order.';
+
       toast({
         title: "Order failed",
         description: message,


### PR DESCRIPTION
## Summary
- ensure EcoCash payments fetch handles non-OK responses and parses the JSON payload before using it
- provide a resilient checkout failure toast message when an error is thrown during submission

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e63e8d2698832098383a297875ccd7